### PR TITLE
version set for junit in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,8 @@
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
-                <artifactId>4.12</artifactId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
I needed to set version variable for junit in pom.xml to be able to successfully run 'mvn install' of extract-cli