### PR TITLE
fix: resetting mark exception

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractor.java
@@ -79,7 +79,9 @@ public class EmbeddedDocumentMemoryExtractor {
                     }
                 }
                 digester.digest(tis, metadata, context);
-                tis.reset();
+                if (stream.getClass().cast(stream).markSupported()) { // Avoid mark/reset error for unsupported inputstreams
+                    tis.reset();
+                }
                 String digest;
                 try {
                     digest = new DigestIdentifier(algorithm, Charset.defaultCharset()).generateForEmbed(embed);


### PR DESCRIPTION
**Goal**
This PR aims to fix the first error stated in [this issue](https://github.com/ICIJ/datashare/issues/1135).

**Explanation**
This exception happens when an `InputStream` doesn't properly support marks and its `reset()` is called. In our case, our `InputStearm` is wrapped into a `TikaInputStream` ([here](https://github.com/ICIJ/extract/blob/1ecabee74e445e8226bc71489891d21a34410984/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractor.java#L73C63-L73C63)) which is natively support marks, if the original `InputSteam` does not support marking, it's wrapped into a `TikaInputStream` through a `BufferedInputStream` which causes the exception when the `reset()` is used. In this PR we check if this function is allowed beforehand