### PR TITLE
fix: mark before reset to initialize mark position ICIJ/datashare#1135

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractor.java
@@ -79,9 +79,8 @@ public class EmbeddedDocumentMemoryExtractor {
                     }
                 }
                 digester.digest(tis, metadata, context);
-                if (stream.getClass().cast(stream).markSupported()) { // Avoid mark/reset error for unsupported inputstreams
-                    tis.reset();
-                }
+                tis.mark(0); // Marking the position before resetting
+                tis.reset();
                 String digest;
                 try {
                     digest = new DigestIdentifier(algorithm, Charset.defaultCharset()).generateForEmbed(embed);


### PR DESCRIPTION
**Goal**
This PR aims to fix the first error stated in [this issue](https://github.com/ICIJ/datashare/issues/1135).

**Explanation**
In the [previous PR](https://github.com/ICIJ/extract/pull/34) I assumed that the error was due to the `InputStreams` which didn't support marks. In fact this error can even be raised on streams that support marks. In this PR, I propose to mark the position before resetting it.