### PR TITLE
feat: delete on queue and reportmap

### DIFF
--- a/extract-cli/src/main/java/org/icij/extract/mysql/MySQLBlockingQueue.java
+++ b/extract-cli/src/main/java/org/icij/extract/mysql/MySQLBlockingQueue.java
@@ -21,6 +21,12 @@ public class MySQLBlockingQueue<E> extends SQLBlockingQueue<E> {
 		this.codec = codec;
 	}
 
+	public boolean delete() {
+		return source.withStatementUnchecked("TRUNCATE FROM " + table, q -> {
+			return q.executeUpdate() > 0;
+		});
+	}
+
 	@Override
 	public boolean remove(final Object o) {
 		Objects.requireNonNull(o);

--- a/extract-cli/src/main/java/org/icij/extract/mysql/MySQLBlockingQueue.java
+++ b/extract-cli/src/main/java/org/icij/extract/mysql/MySQLBlockingQueue.java
@@ -22,7 +22,7 @@ public class MySQLBlockingQueue<E> extends SQLBlockingQueue<E> {
 	}
 
 	public boolean delete() {
-		return source.withStatementUnchecked("TRUNCATE FROM " + table, q -> {
+		return source.withStatementUnchecked("TRUNCATE FROM " + table + ";", q -> {
 			return q.executeUpdate() > 0;
 		});
 	}

--- a/extract-cli/src/main/java/org/icij/extract/mysql/MySQLConcurrentMap.java
+++ b/extract-cli/src/main/java/org/icij/extract/mysql/MySQLConcurrentMap.java
@@ -174,6 +174,12 @@ public class MySQLConcurrentMap<K, V> extends SQLConcurrentMap<K, V> {
 				(CheckedConsumer<PreparedStatement>) PreparedStatement::executeUpdate);
 	}
 
+	public boolean delete() {
+		return dataSource.withStatementUnchecked("TRUNCATE FROM " + table + ";", q -> {
+			return q.executeUpdate() > 0;
+		});
+	}
+
 	@Override
 	public boolean remove(final Object key, final Object value) {
 		return dataSource.withConnectionUnchecked(c -> {

--- a/extract-lib/pom.xml
+++ b/extract-lib/pom.xml
@@ -196,6 +196,12 @@
             <version>1.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 </project>

--- a/extract-lib/src/main/java/org/icij/extract/queue/DocumentQueue.java
+++ b/extract-lib/src/main/java/org/icij/extract/queue/DocumentQueue.java
@@ -14,6 +14,7 @@ import java.util.concurrent.BlockingQueue;
  */
 public interface DocumentQueue extends BlockingQueue<Path>, AutoCloseable {
     String getName();
+    boolean delete();
 
     default boolean remove(Object o, int count) {
         boolean removed = false;

--- a/extract-lib/src/main/java/org/icij/extract/queue/MemoryDocumentQueue.java
+++ b/extract-lib/src/main/java/org/icij/extract/queue/MemoryDocumentQueue.java
@@ -34,6 +34,11 @@ public class MemoryDocumentQueue extends ArrayBlockingQueue<Path> implements Doc
 		this.queueName = queueName;
 	}
 
+	public boolean delete() {
+		this.clear();
+		return true;
+	}
+
 	@Override
 	public void close() {}
 

--- a/extract-lib/src/main/java/org/icij/extract/redis/RedisDocumentQueue.java
+++ b/extract-lib/src/main/java/org/icij/extract/redis/RedisDocumentQueue.java
@@ -95,6 +95,7 @@ public class RedisDocumentQueue extends RedissonBlockingQueue<Path> implements D
 		return "RedisDocumentQueue{name=" + getName() + '}';
 	}
 
+
 	/**
 	 * Codec for a queue of paths to documents.
 	 */

--- a/extract-lib/src/main/java/org/icij/extract/report/HashMapReportMap.java
+++ b/extract-lib/src/main/java/org/icij/extract/report/HashMapReportMap.java
@@ -26,4 +26,10 @@ public class HashMapReportMap extends ConcurrentHashMap<Path, Report> implements
 
 	@Override
 	public void close() {}
+
+	@Override
+	public boolean delete() {
+		clear();
+		return size() == 0;
+	}
 }

--- a/extract-lib/src/main/java/org/icij/extract/report/ReportMap.java
+++ b/extract-lib/src/main/java/org/icij/extract/report/ReportMap.java
@@ -22,6 +22,8 @@ public interface ReportMap extends ConcurrentMap<Path, Report>, AutoCloseable {
 	 */
 	boolean fastPut(final Path key, final Report value);
 
+	boolean delete();
+
 	/**
 	 * Allow implementations to define a list of exception classes that when caught, would indicate to the caller
 	 * that arguments should be journaled and flushed later.
@@ -31,4 +33,5 @@ public interface ReportMap extends ConcurrentMap<Path, Report>, AutoCloseable {
 	default Collection<Class<? extends Exception>> journalableExceptions() {
 		return null;
 	}
+
 }

--- a/extract-lib/src/test/java/org/icij/extract/queue/ArrayTikaDocumentQueueTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/queue/ArrayTikaDocumentQueueTest.java
@@ -23,6 +23,16 @@ public class ArrayTikaDocumentQueueTest {
     }
 
     @Test
+    public void testDeleteClearsTheQueue() {
+        final DocumentQueue queue = createQueue(get("/foo/bar"));
+
+        Assert.assertEquals(1, queue.size());
+        queue.delete();
+        Assert.assertEquals(0, queue.size());
+    }
+
+
+    @Test
     public void testRemoveDuplicates() {
         final DocumentQueue queue = createQueue(get("/foo/bar"), get("/foo/baz"), get("/foo/bar"));
 

--- a/extract-lib/src/test/java/org/icij/extract/redis/RedisDocumentQueueTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/redis/RedisDocumentQueueTest.java
@@ -27,5 +27,16 @@ public class RedisDocumentQueueTest {
         assertThat(queue.size()).isEqualTo(2);
     }
 
+    @Test
+    public void testDelete() throws Exception {
+        queue.put(get("/foo/bar"));
+        queue.put(get("/foo/baz"));
+        queue.put(get("/foo/bar"));
+        queue.put(get("/foo/bar"));
+        assertThat(queue.size()).isEqualTo(4);
+        queue.delete();
+        assertThat(queue.size()).isEqualTo(0);
+    }
+
     @After public void tearDown() { queue.delete();}
 }

--- a/extract-lib/src/test/java/org/icij/extract/redis/RedisReportMapTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/redis/RedisReportMapTest.java
@@ -83,6 +83,18 @@ public class RedisReportMapTest {
         assertThat(reportMap.get(key).getStatus()).isEqualTo(ExtractionStatus.SUCCESS);
     }
 
+    @Test
+    public void test_delete_success() {
+        Path key = Paths.get("/my/path");
+        reportMap.fastPut(key, new Report(ExtractionStatus.SUCCESS));
+        assertThat(reportMap.size()).isEqualTo(1);
+        assertThat(reportMap.delete()).isTrue();
+        assertThat(reportMap.size()).isEqualTo(0);
+    }
+
+
+
+
     @After
     public void tearDown() {
         reportMap.delete();

--- a/extract-lib/src/test/java/org/icij/extract/report/HashMapReportMapTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/report/HashMapReportMapTest.java
@@ -1,0 +1,36 @@
+package org.icij.extract.report;
+
+import org.icij.extract.extractor.ExtractionStatus;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class HashMapReportMapTest {
+    private HashMapReportMap reportMap = new HashMapReportMap();
+
+    @Test
+    public void test_insert_success() {
+        Path key = Paths.get("/my/path");
+        reportMap.fastPut(key, new Report(ExtractionStatus.SUCCESS));
+        assertThat(reportMap.get(key).getStatus()).isEqualTo(ExtractionStatus.SUCCESS);
+        assertThat(reportMap.get(key).getException().isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_correct_size() {
+        reportMap.fastPut(Paths.get("/my/path/foo"), new Report(ExtractionStatus.SUCCESS));
+        reportMap.fastPut(Paths.get("/my/path/bar"), new Report(ExtractionStatus.FAILURE_UNKNOWN));
+        assertThat(reportMap.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void test_delete() {
+        reportMap.fastPut(Paths.get("/my/path/foo"), new Report(ExtractionStatus.SUCCESS));
+        reportMap.fastPut(Paths.get("/my/path/bar"), new Report(ExtractionStatus.FAILURE_UNKNOWN));
+        assertThat(reportMap.delete()).isTrue();
+        assertThat(reportMap.size()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## PR description

Ensure both `DocumentQueue` and `ReportMap` expose a delete method on their interface so we can remove them regardless of the used backend.