### PR TITLE
fix: embedded extractor mark/reset failure + skip redundant OCR

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -12,6 +12,7 @@ import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.DigestingParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
+import org.apache.tika.parser.ocr.TesseractOCRConfig;
 import org.apache.tika.sax.BodyContentHandler;
 import org.icij.extract.document.EmbeddedTikaDocument;
 import org.icij.extract.document.TikaDocument;
@@ -37,6 +38,7 @@ public class EmbeddedDocumentExtractor {
     private final DigestingParser.Digester digester;
     private final String algorithm;
     private final Path artifactPath;
+    private final boolean ocr;
     private static final ModuleDescriptor.Version TIKA_3_2_3 = ModuleDescriptor.Version.parse("3.2.3");
 
     public EmbeddedDocumentExtractor(UpdatableDigester digester) {
@@ -56,13 +58,32 @@ public class EmbeddedDocumentExtractor {
         this.digester = digester;
         this.artifactPath = artifactPath;
         this.algorithm = algorithm;
+        this.ocr = ocr;
+    }
+
+    /**
+     * Builds the parse context. When OCR is enabled we keep the OCR parser in the parser set
+     * (so image types are still detected/routed and the embedded entries are produced with the
+     * same identifiers as at index time) but skip the actual text recognition: extracting an
+     * embedded *source* only needs the entry bytes and their digest, never the OCR text. The
+     * digest is computed before the recognition step would run, so skipping it reproduces the
+     * exact same embedded document without paying the Tesseract cost.
+     */
+    private ParseContext newParseContext() {
+        ParseContext context = new ParseContext();
+        context.set(Parser.class, parser);
+        if (ocr) {
+            TesseractOCRConfig ocrConfig = new TesseractOCRConfig();
+            ocrConfig.setSkipOcr(true);
+            context.set(TesseractOCRConfig.class, ocrConfig);
+        }
+        return context;
     }
 
     public void extractAll(final TikaDocument document) throws SAXException, TikaException, IOException {
         ofNullable(artifactPath).orElseThrow(() -> new IllegalStateException("cannot extract all embedded files in memory"));
-        ParseContext context = new ParseContext();
+        ParseContext context = newParseContext();
         ContentHandler handler = new BodyContentHandler(-1);
-        context.set(Parser.class, parser);
 
         DigestEmbeddedDocumentExtractor extractor = new DigestAllEmbeddedDocumentExtractor(document, context, digester, algorithm, artifactPath);
         context.set(org.apache.tika.extractor.EmbeddedDocumentExtractor.class, extractor);
@@ -77,9 +98,8 @@ public class EmbeddedDocumentExtractor {
                 return new TikaDocumentSource(MetadataTransformer.loadMetadata(new File(cachedFile + ".json")), DigestEmbeddedDocumentFileExtractor.getFileInputStream(cachedFile));
             }
         }
-        ParseContext context = new ParseContext();
+        ParseContext context = newParseContext();
         ContentHandler handler = new BodyContentHandler(-1);
-        context.set(Parser.class, parser);
 
         DigestEmbeddedDocumentFileExtractor extractor = getExtractor(rootDocument, embeddedDocumentDigest, context, artifactPath);
         context.set(org.apache.tika.extractor.EmbeddedDocumentExtractor.class, extractor);

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -154,10 +154,15 @@ public class EmbeddedDocumentExtractor {
                     // Cache the embed id now while metadata still holds the correct hash:
                     // super.delegateParsing below triggers DigestingParser which overwrites it.
                     String digest = embed.getId();
-                    documentCallback(metadata, digest, spooled);
+                    boolean found = documentCallback(metadata, digest, spooled);
                     this.documentStack.add(embed);
-                    try (TikaInputStream parseStream = TikaInputStream.get(spooled)) {
-                        super.delegateParsing(parseStream, handler, metadata);
+                    // Once the target embed is captured, skip recursing into it: its content is
+                    // already saved and recursion would parse/OCR it needlessly. Combined with
+                    // shouldParseEmbedded() returning false afterwards, this stops the walk early.
+                    if (!found) {
+                        try (TikaInputStream parseStream = TikaInputStream.get(spooled)) {
+                            super.delegateParsing(parseStream, handler, metadata);
+                        }
                     }
                     return;
                 }
@@ -189,9 +194,11 @@ public class EmbeddedDocumentExtractor {
                 // without pre-caching, lazy getId() on this embed would compute with the wrong hash
                 // and break ID lookups for any child embeds that reference this embed as parent.
                 String digest = embed.getId();
-                documentCallback(metadata, digest, tis);
+                boolean found = documentCallback(metadata, digest, tis);
                 this.documentStack.add(embed);
-                super.delegateParsing(tis, handler, metadata);
+                if (!found) {
+                    super.delegateParsing(tis, handler, metadata);
+                }
             } finally {
                 this.documentStack.removeLast();
             }
@@ -248,6 +255,15 @@ public class EmbeddedDocumentExtractor {
         private DigestEmbeddedDocumentFileExtractor(final TikaDocument rootDocument, final String digestToFind, ParseContext context, DigestingParser.Digester digester, String algorithm, Path artifactDir) {
             super(rootDocument, context, digester, algorithm, artifactDir);
             this.digestToFind = digestToFind;
+        }
+
+        @Override
+        public boolean shouldParseEmbedded(Metadata metadata) {
+            // Stop descending once the target embed has been found. Tika checks this before
+            // parsing each embedded entry, so returning false skips the remaining (potentially
+            // OCR-heavy) entries instead of walking the whole archive. (Throwing to abort does
+            // not work here: PackageParser catches Throwable per entry and continues.)
+            return document == null && super.shouldParseEmbedded(metadata);
         }
 
         @Override

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -62,12 +62,12 @@ public class EmbeddedDocumentExtractor {
     }
 
     /**
-     * Builds the parse context. When OCR is enabled we keep the OCR parser in the parser set
-     * (so image types are still detected/routed and the embedded entries are produced with the
-     * same identifiers as at index time) but skip the actual text recognition: extracting an
-     * embedded *source* only needs the entry bytes and their digest, never the OCR text. The
-     * digest is computed before the recognition step would run, so skipping it reproduces the
-     * exact same embedded document without paying the Tesseract cost.
+     * Builds the parse context. When OCR is enabled we keep the OCR parser registered (rather
+     * than excluding it as createParserWithoutOCR does), so OCR-routed image embeds are still
+     * produced with the same identifiers as at index time, but we set skipOcr so Tesseract does
+     * not actually run. Extracting an embedded *source* only needs the entry bytes and their
+     * digest (which is computed before the recognition step would run), never the OCR text, so
+     * skipping recognition reproduces the identical embedded document without the Tesseract cost.
      */
     private ParseContext newParseContext() {
         ParseContext context = new ParseContext();
@@ -166,7 +166,8 @@ public class EmbeddedDocumentExtractor {
                     // This avoids the in-memory mark()/reset() on the embedded stream, which
                     // fails with "Resetting to invalid mark" (surfaced as TIKA-198 from
                     // PackageParser) once an entry exceeds the digester's mark limit, and keeps
-                    // memory use bounded regardless of entry size.
+                    // the per-entry parse memory bounded regardless of entry size. (The memory
+                    // extractor still buffers the single matched entry into a byte[] by design.)
                     final Path spooled = tis.getPath();
                     try (TikaInputStream digestStream = TikaInputStream.get(spooled)) {
                         digester.digest(digestStream, metadata, context);
@@ -281,8 +282,8 @@ public class EmbeddedDocumentExtractor {
         public boolean shouldParseEmbedded(Metadata metadata) {
             // Stop descending once the target embed has been found. Tika checks this before
             // parsing each embedded entry, so returning false skips the remaining (potentially
-            // OCR-heavy) entries instead of walking the whole archive. (Throwing to abort does
-            // not work here: PackageParser catches Throwable per entry and continues.)
+            // OCR-heavy) entries instead of walking the whole archive. This hook is the clean
+            // way to short-circuit: it needs no exception and works the same for every container.
             return document == null && super.shouldParseEmbedded(metadata);
         }
 

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -121,6 +121,7 @@ public class EmbeddedDocumentExtractor {
         }
 
         protected abstract boolean documentCallback(Metadata metadata, String digest, TikaInputStream tis) throws IOException;
+        protected abstract boolean documentCallback(Metadata metadata, String digest, Path spooled) throws IOException;
 
         @Override
         void delegateParsing(InputStream stream, ContentHandler handler, Metadata metadata) throws IOException, SAXException {
@@ -133,11 +134,35 @@ public class EmbeddedDocumentExtractor {
                         tis.setOpenContainer(container);
                     }
                 }
-                tis.mark(0); // Marking the position before resetting
                 // this if/else is coming from DigestingParser since 3.3.0 to fix issues with Microsoft OLE docs
                 // see https://issues.apache.org/jira/browse/TIKA-4533
                 boolean shouldTranslate = embeddedStreamTranslator.shouldTranslate(tis, metadata);
                 boolean retroCompat = documentTikaVersion.compareTo(TIKA_3_2_3) <= 0;
+
+                if (!(shouldTranslate && !retroCompat) && tis.getOpenContainer() == null) {
+                    // Raw (non-translated) entry from a container such as a zip/tar archive.
+                    // Spool the entry to a temp file once, then read independent file-backed
+                    // streams for the digest, the document callback and the recursive parse.
+                    // This avoids the in-memory mark()/reset() on the embedded stream, which
+                    // fails with "Resetting to invalid mark" (surfaced as TIKA-198 from
+                    // PackageParser) once an entry exceeds the digester's mark limit, and keeps
+                    // memory use bounded regardless of entry size.
+                    final Path spooled = tis.getPath();
+                    try (TikaInputStream digestStream = TikaInputStream.get(spooled)) {
+                        digester.digest(digestStream, metadata, context);
+                    }
+                    // Cache the embed id now while metadata still holds the correct hash:
+                    // super.delegateParsing below triggers DigestingParser which overwrites it.
+                    String digest = embed.getId();
+                    documentCallback(metadata, digest, spooled);
+                    this.documentStack.add(embed);
+                    try (TikaInputStream parseStream = TikaInputStream.get(spooled)) {
+                        super.delegateParsing(parseStream, handler, metadata);
+                    }
+                    return;
+                }
+
+                tis.mark(0); // Marking the position before resetting
                 if (shouldTranslate && !retroCompat) {
                     // Tika >= 3.3.0: hash the translated bytes so the digest matches the actual content
                     Path translatedBytes;
@@ -186,6 +211,16 @@ public class EmbeddedDocumentExtractor {
             tis.reset();
             return embedded;
         }
+
+        protected File writeFile(Metadata metadata, String digest, Path source) throws IOException {
+            File embedded = getEmbeddedPath(this.artifactPath, digest).toFile();
+            Files.createDirectories(Paths.get(embedded.getParent()));
+            Files.copy(source, embedded.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            try (FileOutputStream metadataOutputStream = new FileOutputStream(embedded + ".json")) {
+                metadataOutputStream.write(new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
+            }
+            return embedded;
+        }
     }
 
     static class DigestAllEmbeddedDocumentExtractor extends DigestEmbeddedDocumentExtractor {
@@ -196,6 +231,12 @@ public class EmbeddedDocumentExtractor {
         @Override
         protected boolean documentCallback(Metadata metadata, String digest, TikaInputStream tis) throws IOException {
             writeFile(metadata, digest, tis);
+            return false;
+        }
+
+        @Override
+        protected boolean documentCallback(Metadata metadata, String digest, Path spooled) throws IOException {
+            writeFile(metadata, digest, spooled);
             return false;
         }
     }
@@ -221,6 +262,21 @@ public class EmbeddedDocumentExtractor {
 
         protected Supplier<InputStream> getInputStreamSupplier(Metadata metadata, String digest, TikaInputStream tis) throws IOException {
             File embedded = writeFile(metadata, digest, tis);
+            return getFileInputStream(embedded);
+        }
+
+        @Override
+        protected boolean documentCallback(Metadata metadata, String digest, Path spooled) throws IOException {
+            if (digestToFind.equals(digest)) {
+                Supplier<InputStream> inputStreamSupplier = getInputStreamSupplier(metadata, digest, spooled);
+                this.document = new TikaDocumentSource(metadata, inputStreamSupplier);
+                return true;
+            }
+            return false;
+        }
+
+        protected Supplier<InputStream> getInputStreamSupplier(Metadata metadata, String digest, Path spooled) throws IOException {
+            File embedded = writeFile(metadata, digest, spooled);
             return getFileInputStream(embedded);
         }
 
@@ -254,6 +310,12 @@ public class EmbeddedDocumentExtractor {
                 buffer.write(tmp, 0, nbTmpBytesRead); // uses the memory
             }
             return () -> new ByteArrayInputStream(buffer.toByteArray());
+        }
+
+        @Override
+        protected Supplier<InputStream> getInputStreamSupplier(Metadata metadata, String digest, Path spooled) throws IOException {
+            byte[] bytes = Files.readAllBytes(spooled);
+            return () -> new ByteArrayInputStream(bytes);
         }
     }
 

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
@@ -15,8 +15,12 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.Fail.fail;
@@ -191,6 +195,46 @@ public class EmbeddedDocumentMemoryExtractorTest {
         //THEN
         assertThat(pngFile).isNotNull();
         assertThat(new String(pngFile.getContent())).hasSize(634);
+    }
+
+    @Test
+    public void test_large_embedded_entry_in_archive_is_extractable() throws Exception {
+        //GIVEN a zip containing one entry larger than the UpdatableDigester mark limit
+        // UpdatableDigester uses a 20MB mark limit; an embedded entry larger than it
+        // cannot be rewound via mark()/reset(), which is what triggered the bug.
+        int markLimit = 20 * 1024 * 1024;
+        int entrySize = markLimit + 1024 * 1024;
+        Path zip = tmp.newFile("big.zip").toPath();
+        byte[] content = new byte[entrySize];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) (i % 251);
+        }
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip))) {
+            zos.putNextEntry(new ZipEntry("big.bin"));
+            zos.write(content);
+            zos.closeEntry();
+        }
+
+        // discover the embedded entry id via the normal extractor (EmbedSpawner path,
+        // which is unaffected by the mark/reset bug)
+        Extractor extractor = new Extractor(documentFactory);
+        extractor.setDigester(new UpdatableDigester("prj", "SHA-256"));
+        TikaDocument extracted = extractor.extract(zip);
+        try (Reader reader = extracted.getReader()) {
+            Spewer.toString(reader);
+        }
+        assertThat(extracted.getEmbeds()).hasSize(1);
+        String bigEntryId = extracted.getEmbeds().get(0).getId();
+
+        EmbeddedDocumentExtractor contentExtractor = new EmbeddedDocumentExtractor(
+                new UpdatableDigester("prj", "SHA-256"), tmp.getRoot().toPath());
+
+        //WHEN extracting the large embedded entry on demand
+        TikaDocumentSource source = contentExtractor.extract(extracted, bigEntryId);
+
+        //THEN it returns the full entry instead of failing to reset the stream
+        assertThat(source).isNotNull();
+        assertThat(source.getContent()).hasSize(entrySize);
     }
 
     @Test


### PR DESCRIPTION
Extracting an embedded source from a container (zip/tar/OLE) could fail with `Resetting to invalid mark` (surfaced as TIKA-198 from `PackageParser`) once an entry grew past the digester's in-memory mark limit. This branch reworks the embedded extraction path to spool raw entries to a temp file instead of relying on `mark()`/`reset()` on the embedded stream, and trims unnecessary work while walking the container.

## Changes

- **fix: spool entries to a temp file.** Drops the in-memory `mark()`/`reset()` that failed on large entries. Memory stays bounded whatever the entry size.
- **perf: stop the walk once the target is found.** No longer descends into the rest of the archive after the requested embed is captured.
- **perf: skip OCR when extracting sources.** A source only needs the bytes and their digest, not the recognized text, so Tesseract no longer runs. Identifiers stay the same as at index time.

## Benchmarks

End-to-end download of a single OCR-derived embedded image (`image/ocr-png`, 693,900 bytes) from a 102 MB zip (1,881 entries, including ten ~2 MB PDFs) through the datashare download endpoint. Single runs on the test machine; "cold" = empty artifact cache, "warm" = served from `--artifactDir`.

| Variant | Cold | Notes |
| --- | --- | --- |
| Full re-OCR (OCR on, recognition runs) | ~235s | Tesseract runs on every image/PDF in the archive |
| + stop-the-walk on match | ~210s | ~11% here; depends on the target's position |
| + skip OCR recognition (this branch) | **~6s** | ~38× faster; byte-identical output |
| Artifact cache hit (warm) | **~0.09s** | no re-extraction at all |

The dominant cost was Tesseract recognition, which a source download never needs; skipping it (while keeping the OCR parser registered so identifiers match) is what takes the cold path from minutes to seconds. The artifact cache then removes re-extraction entirely on subsequent requests.


## AI Discolsure

I used Claude for root-cause investigation (including live JVM debugging of the running app), implementing the tests and gathering the benchmark figures above.