### PR TITLE
feat: memory-bounded extraction for large PSTs

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
@@ -1,0 +1,116 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.io.TemporaryResources;
+import org.icij.extract.document.TikaDocument.ReaderGenerator;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Buffers one embedded document's extracted text in memory while a shared, per-extraction
+ * byte budget allows, overflowing to a temp file once the budget would be exceeded. Once
+ * spilled, the buffer stays on disk. The text is read back lazily during the spew walk.
+ *
+ * <p>The shared {@link AtomicLong} models the bytes currently resident in memory across all
+ * of an extraction's buffers; it gates when spilling begins during the (single-threaded)
+ * parse. Resident bytes are released from the counter when they are moved to disk or when
+ * the embed is discarded on error.
+ */
+class BudgetedEmbedBuffer extends OutputStream {
+
+    private final AtomicLong reserved;
+    private final long budgetBytes;
+    private final TemporaryResources tmp;
+
+    private ByteArrayOutputStream memory = new ByteArrayOutputStream(8192);
+    private long memoryReserved = 0;
+    private Path file = null;
+    private OutputStream fileOut = null;
+    private boolean closed = false;
+
+    BudgetedEmbedBuffer(final AtomicLong reserved, final long budgetBytes, final TemporaryResources tmp) {
+        this.reserved = reserved;
+        this.budgetBytes = budgetBytes;
+        this.tmp = tmp;
+    }
+
+    @Override
+    public synchronized void write(final int b) throws IOException {
+        write(new byte[]{(byte) b}, 0, 1);
+    }
+
+    @Override
+    public synchronized void write(final byte[] b, final int off, final int len) throws IOException {
+        if (closed) {
+            throw new IOException("Stream closed");
+        }
+        if (file != null) {
+            fileOut.write(b, off, len);
+            return;
+        }
+        if (reserved.get() + len > budgetBytes) {
+            spill();
+            fileOut.write(b, off, len);
+            return;
+        }
+        memory.write(b, off, len);
+        memoryReserved += len;
+        reserved.addAndGet(len);
+    }
+
+    private void spill() throws IOException {
+        file = tmp.createTempFile();
+        fileOut = new BufferedOutputStream(Files.newOutputStream(file));
+        memory.writeTo(fileOut);
+        reserved.addAndGet(-memoryReserved);
+        memoryReserved = 0;
+        memory = null;
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (fileOut != null) {
+            fileOut.close();
+        }
+    }
+
+    /** Release this buffer's resident memory bytes from the shared counter (error path). */
+    synchronized void discard() {
+        if (memoryReserved > 0) {
+            reserved.addAndGet(-memoryReserved);
+            memoryReserved = 0;
+        }
+        memory = null;
+    }
+
+    /** A lazy reader over the buffered text, from memory or the temp file. */
+    ReaderGenerator readerGenerator() {
+        return () -> {
+            synchronized (this) {
+                if (file != null) {
+                    return new InputStreamReader(Files.newInputStream(file), StandardCharsets.UTF_8);
+                }
+                if (memory == null) {
+                    throw new IOException("Embed buffer was discarded; no content to read");
+                }
+                return new InputStreamReader(new ByteArrayInputStream(memory.toByteArray()), StandardCharsets.UTF_8);
+            }
+        };
+    }
+
+    synchronized boolean isSpilled() {
+        return file != null;
+    }
+}

--- a/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
@@ -88,6 +88,7 @@ class BudgetedEmbedBuffer extends OutputStream {
 
     /** Release this buffer's resident memory bytes from the shared counter (error path). */
     synchronized void discard() {
+        // Only called on the spool-failure path, before any write, so fileOut is always null here; close() owns fileOut.
         if (memoryReserved > 0) {
             reserved.addAndGet(-memoryReserved);
             memoryReserved = 0;

--- a/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
@@ -60,18 +60,27 @@ class BudgetedEmbedBuffer extends OutputStream {
         if (closed) {
             throw new IOException("Stream closed");
         }
-        if (file != null) {
+        // Once this buffer has spilled it stays on disk for the rest of its life.
+        if (isSpilled()) {
             fileOut.write(b, off, len);
             return;
         }
-        // Spill when the shared in-memory budget would be exceeded, or when the heap is already under
-        // pressure — the latter keeps total memory bounded even when the document tree, not the embed
-        // text, is what is filling the heap (e.g. mailboxes with tens of thousands of items).
-        if (reserved.get() + len > budgetBytes || memoryPressureHigh.getAsBoolean()) {
+        if (shouldSpill(len)) {
             spill();
             fileOut.write(b, off, len);
             return;
         }
+        appendToMemory(b, off, len);
+    }
+
+    // Spill when the shared in-memory budget would be exceeded, or when the heap is already under
+    // pressure — the latter keeps total memory bounded even when the document tree, not the embed
+    // text, is what is filling the heap (e.g. mailboxes with tens of thousands of items).
+    private boolean shouldSpill(final int len) {
+        return reserved.get() + len > budgetBytes || memoryPressureHigh.getAsBoolean();
+    }
+
+    private void appendToMemory(final byte[] b, final int off, final int len) throws IOException {
         memory.write(b, off, len);
         memoryReserved += len;
         reserved.addAndGet(len);

--- a/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
@@ -99,12 +99,23 @@ class BudgetedEmbedBuffer extends OutputStream {
 
     /** Release this buffer's resident memory bytes from the shared counter (error path). */
     synchronized void discard() {
-        // Only called on the spool-failure path, before any write, so fileOut is always null here; close() owns fileOut.
         if (memoryReserved > 0) {
             reserved.addAndGet(-memoryReserved);
             memoryReserved = 0;
         }
         memory = null;
+        // Today discard() is only reached on the spool-failure path before any byte is written, so
+        // fileOut is null. Stay robust to a future caller reaching it after a spill: release the open
+        // stream so its descriptor isn't leaked. The temp file itself is owned by the shared
+        // TemporaryResources and reclaimed when those close.
+        if (fileOut != null) {
+            try {
+                fileOut.close();
+            } catch (final IOException ignored) {
+                // best-effort: nothing actionable on the error path
+            }
+            fileOut = null;
+        }
     }
 
     /** A lazy reader over the buffered text, from memory or the temp file. */

--- a/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/BudgetedEmbedBuffer.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
 
 /**
  * Buffers one embedded document's extracted text in memory while a shared, per-extraction
@@ -29,6 +30,7 @@ class BudgetedEmbedBuffer extends OutputStream {
     private final AtomicLong reserved;
     private final long budgetBytes;
     private final TemporaryResources tmp;
+    private final BooleanSupplier memoryPressureHigh;
 
     private ByteArrayOutputStream memory = new ByteArrayOutputStream(8192);
     private long memoryReserved = 0;
@@ -37,9 +39,15 @@ class BudgetedEmbedBuffer extends OutputStream {
     private boolean closed = false;
 
     BudgetedEmbedBuffer(final AtomicLong reserved, final long budgetBytes, final TemporaryResources tmp) {
+        this(reserved, budgetBytes, tmp, () -> false);
+    }
+
+    BudgetedEmbedBuffer(final AtomicLong reserved, final long budgetBytes, final TemporaryResources tmp,
+                        final BooleanSupplier memoryPressureHigh) {
         this.reserved = reserved;
         this.budgetBytes = budgetBytes;
         this.tmp = tmp;
+        this.memoryPressureHigh = memoryPressureHigh;
     }
 
     @Override
@@ -56,7 +64,10 @@ class BudgetedEmbedBuffer extends OutputStream {
             fileOut.write(b, off, len);
             return;
         }
-        if (reserved.get() + len > budgetBytes) {
+        // Spill when the shared in-memory budget would be exceeded, or when the heap is already under
+        // pressure — the latter keeps total memory bounded even when the document tree, not the embed
+        // text, is what is filling the heap (e.g. mailboxes with tens of thousands of items).
+        if (reserved.get() + len > budgetBytes || memoryPressureHigh.getAsBoolean()) {
             spill();
             fileOut.write(b, off, len);
             return;

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
 import static java.lang.Boolean.parseBoolean;
@@ -36,16 +37,19 @@ public class EmbedSpawner extends EmbedParser {
 	private int untitled = 0;
 	private final long embedMemoryBudgetBytes;
 	private final TemporaryResources tmp;
+	private final BooleanSupplier memoryPressureHigh;
 	private final AtomicLong reserved = new AtomicLong();
 
 	EmbedSpawner(final TikaDocument root, final ParseContext context, final Path outputPath,
 				 final Function<Writer, ContentHandler> handlerFunction,
-				 final long embedMemoryBudgetBytes, final TemporaryResources tmp) {
+				 final long embedMemoryBudgetBytes, final TemporaryResources tmp,
+				 final BooleanSupplier memoryPressureHigh) {
 		super(root, context);
 		this.outputPath = outputPath;
 		this.handlerFunction = handlerFunction;
 		this.embedMemoryBudgetBytes = embedMemoryBudgetBytes;
 		this.tmp = tmp;
+		this.memoryPressureHigh = memoryPressureHigh;
 		tikaDocumentStack.add(root);
 	}
 
@@ -84,7 +88,7 @@ public class EmbedSpawner extends EmbedParser {
 		// Buffer the embed's extracted text in memory while the global budget allows,
 		// overflowing to a temp file once exceeded, so multi-GB containers (PSTs, zips,
 		// mailboxes) don't retain the whole tree's text in heap at once.
-		final BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, embedMemoryBudgetBytes, tmp);
+		final BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, embedMemoryBudgetBytes, tmp, memoryPressureHigh);
 		final Writer writer = new OutputStreamWriter(buffer, StandardCharsets.UTF_8);
 
 		final ContentHandler embedHandler = handlerFunction.apply(writer);

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -21,6 +21,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
 import static java.lang.Boolean.parseBoolean;
@@ -33,12 +34,18 @@ public class EmbedSpawner extends EmbedParser {
 	private final Function<Writer, ContentHandler> handlerFunction;
 	private final LinkedList<TikaDocument> tikaDocumentStack = new LinkedList<>();
 	private int untitled = 0;
+	private final long embedMemoryBudgetBytes;
+	private final TemporaryResources tmp;
+	private final AtomicLong reserved = new AtomicLong();
 
 	EmbedSpawner(final TikaDocument root, final ParseContext context, final Path outputPath,
-				 final Function<Writer, ContentHandler> handlerFunction) {
+				 final Function<Writer, ContentHandler> handlerFunction,
+				 final long embedMemoryBudgetBytes, final TemporaryResources tmp) {
 		super(root, context);
 		this.outputPath = outputPath;
 		this.handlerFunction = handlerFunction;
+		this.embedMemoryBudgetBytes = embedMemoryBudgetBytes;
+		this.tmp = tmp;
 		tikaDocumentStack.add(root);
 	}
 
@@ -74,18 +81,18 @@ public class EmbedSpawner extends EmbedParser {
 	}
 
 	private void spawnEmbedded(final TikaInputStream tis, final Metadata metadata) throws IOException {
-		// Create a Writer that will receive the parser output for the embed file, for later retrieval.
-		final ByteArrayOutputStream output = new ByteArrayOutputStream(8192);
-		final Writer writer = new OutputStreamWriter(output, StandardCharsets.UTF_8);
+		// Buffer the embed's extracted text in memory while the global budget allows,
+		// overflowing to a temp file once exceeded, so multi-GB containers (PSTs, zips,
+		// mailboxes) don't retain the whole tree's text in heap at once.
+		final BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, embedMemoryBudgetBytes, tmp);
+		final Writer writer = new OutputStreamWriter(buffer, StandardCharsets.UTF_8);
 
 		final ContentHandler embedHandler = handlerFunction.apply(writer);
 		final EmbeddedTikaDocument embed = tikaDocumentStack.getLast().addEmbed(metadata);
 
-		// Use temporary resources to copy formatted output from the content handler to a temporary file.
-		// Call setReader on the embed object with a plain reader for this temp file.
-		// When all parsing finishes, close temporary resources.
-		// Note that getPath should still return the path to the original file.
-		embed.setReader(() -> new InputStreamReader(new ByteArrayInputStream(output.toByteArray()), StandardCharsets.UTF_8));
+		// The reader is generated lazily during the spew walk, reading from memory or the
+		// temp file depending on whether this embed spilled.
+		embed.setReader(buffer.readerGenerator());
 
 		String name = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
 		if (null == name || name.isEmpty()) {
@@ -94,8 +101,6 @@ public class EmbedSpawner extends EmbedParser {
 
 		try {
 			// Trigger spooling of the file to disk so that it can be copied.
-			// This needs to be done before parsing starts and the same TIS object must be passed to writeEmbed,
-			// otherwise it will be spooled twice.
 			if (null != this.outputPath) {
 				tis.getPath();
 			}
@@ -105,6 +110,7 @@ public class EmbedSpawner extends EmbedParser {
 			// If a document can't be spooled then there's a severe problem with the input stream. Abort.
 			tikaDocumentStack.getLast().removeEmbed(embed);
 			embed.clearReader();
+			buffer.discard();
 			writer.close();
 			return;
 		}
@@ -113,8 +119,6 @@ public class EmbedSpawner extends EmbedParser {
 		tikaDocumentStack.add(embed);
 
 		try {
-			// Pass the same TIS, otherwise the EmbedParser will attempt to spool the input again and fail, because it's
-			// already been consumed.
 			delegateParsing(tis, embedHandler, metadata);
 		} catch (final Exception e) {
 

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -37,6 +37,8 @@ import org.icij.extract.parser.CacheParserDecorator;
 import org.icij.extract.parser.FallbackParser;
 import org.icij.extract.parser.HTML5Serializer;
 import org.icij.extract.parser.ParsingReaderWithContentHandler;
+import org.apache.tika.io.TemporaryResources;
+import org.icij.extract.parser.ResourceClosingReader;
 import org.icij.extract.parser.ResilientOutlookPSTParser;
 import org.icij.extract.report.Reporter;
 import org.icij.spewer.MetadataTransformer;
@@ -562,9 +564,12 @@ public class Extractor {
         // This excludes script tags and objects.
         context.set(HtmlMapper.class, DefaultHtmlMapper.INSTANCE);
 
+        TemporaryResources embedTextResources = null;
         if (EmbedHandling.SPAWN == embedHandling) {
             context.set(Parser.class, parser);
-            context.set(EmbeddedDocumentExtractor.class, new EmbedSpawner(rootDocument, context, embedOutput, handlerProvider));
+            embedTextResources = new TemporaryResources();
+            context.set(EmbeddedDocumentExtractor.class,
+                    new EmbedSpawner(rootDocument, context, embedOutput, handlerProvider, embedMemoryBudgetBytes, embedTextResources));
         } else if (EmbedHandling.CONCATENATE == embedHandling) {
             context.set(Parser.class, parser);
             context.set(EmbeddedDocumentExtractor.class, new EmbedParser(rootDocument, context));
@@ -573,7 +578,11 @@ public class Extractor {
             context.set(EmbeddedDocumentExtractor.class, new EmbedBlocker());
         }
 
-        final Reader reader = new ParsingReaderWithContentHandler(parser, tikaInputStream, rootDocument.getMetadata(), context, handlerProvider);
+        Reader reader = new ParsingReaderWithContentHandler(parser, tikaInputStream, rootDocument.getMetadata(), context, handlerProvider);
+        if (null != embedTextResources) {
+            // Delete spilled embed-text temp files when the root reader is closed.
+            reader = new ResourceClosingReader(reader, embedTextResources);
+        }
         rootDocument.setReader(reader);
 
         return rootDocument;

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -93,8 +93,12 @@ import static org.icij.extract.extractor.ArtifactUtils.getEmbeddedPath;
 @Option(name = "ocr", description = "Enable or disable automatic OCR. On by default.")
 @Option(name = "ocrType", description = "Name of the OCR to use TESSERACT, TESS4J")
 @Option(name = "embedMemoryBudgetMb", description = "Maximum megabytes of embedded-document " +
-        "extracted text to hold in memory before overflowing to temp files. Defaults to 512.",
+        "extracted text to hold in memory before overflowing to temp files. Defaults to 64.",
         parameter = "megabytes")
+@Option(name = "embedMemoryPressureThreshold", description = "Heap occupancy ratio (0-1) above which " +
+        "embedded-document text spills to temp files early, regardless of the byte budget, to keep " +
+        "extraction within the available heap on very large containers. Defaults to 0.7; set to 0 or 1 to disable.",
+        parameter = "ratio")
 public class Extractor {
 
     public static final String PAGES_JSON = "pages.json";
@@ -131,7 +135,8 @@ public class Extractor {
     private OutputFormat outputFormat = OutputFormat.TEXT;
     private EmbedHandling embedHandling = EmbedHandling.getDefault();
     private Path embedOutput = null;
-    private long embedMemoryBudgetBytes = 512L * 1024 * 1024;
+    private long embedMemoryBudgetBytes = 64L * 1024 * 1024;
+    private double embedMemoryPressureThreshold = 0.7;
 
     /**
      * Create a new extractor, which will OCR images by default if Tesseract is available locally, extract inline
@@ -183,8 +188,10 @@ public class Extractor {
         options.get("ocrLanguage", "eng").value().ifPresent(this::setOcrLanguage);
         options.get("ocrTimeout", "12h").parse().asDuration().ifPresent(this::setOcrTimeout);
         options.valueIfPresent("embedOutput").ifPresent(embedOutput -> setEmbedOutputPath(Paths.get(embedOutput)));
-        options.get("embedMemoryBudgetMb", "512").parse().asInteger()
+        options.get("embedMemoryBudgetMb", "64").parse().asInteger()
                 .ifPresent(mb -> setEmbedMemoryBudgetBytes(mb * 1024L * 1024L));
+        options.valueIfPresent("embedMemoryPressureThreshold")
+                .ifPresent(ratio -> setEmbedMemoryPressureThreshold(Double.parseDouble(ratio)));
 
         String algorithm = options.valueIfPresent("digestAlgorithm").orElse("SHA-256");
         setDigestAlgorithm(algorithm);
@@ -273,6 +280,14 @@ public class Extractor {
         this.embedMemoryBudgetBytes = embedMemoryBudgetBytes;
     }
 
+    public double getEmbedMemoryPressureThreshold() {
+        return embedMemoryPressureThreshold;
+    }
+
+    public void setEmbedMemoryPressureThreshold(final double embedMemoryPressureThreshold) {
+        this.embedMemoryPressureThreshold = embedMemoryPressureThreshold;
+    }
+
     /**
      * Set the languages used by Tesseract.
      *
@@ -331,7 +346,17 @@ public class Extractor {
         long before = currentTimeMillis();
         TikaDocument document = extract(path);
         logger.info("{} extracted in {}ms", path, currentTimeMillis() - before);
-        spewer.write(document);
+        try {
+            spewer.write(document);
+        } finally {
+            // The spew walk has read the whole tree by now, so closing the root reader is safe.
+            // This is the end-of-extraction signal that releases any embed-text temp files spilled
+            // past the in-memory budget (see ResourceClosingReader); without it they would leak.
+            final Reader reader = document.getReader();
+            if (null != reader) {
+                reader.close();
+            }
+        }
     }
 
     /**
@@ -569,7 +594,8 @@ public class Extractor {
             context.set(Parser.class, parser);
             embedTextResources = new TemporaryResources();
             context.set(EmbeddedDocumentExtractor.class,
-                    new EmbedSpawner(rootDocument, context, embedOutput, handlerProvider, embedMemoryBudgetBytes, embedTextResources));
+                    new EmbedSpawner(rootDocument, context, embedOutput, handlerProvider, embedMemoryBudgetBytes,
+                            embedTextResources, new MemoryPressureGauge(embedMemoryPressureThreshold)));
         } else if (EmbedHandling.CONCATENATE == embedHandling) {
             context.set(Parser.class, parser);
             context.set(EmbeddedDocumentExtractor.class, new EmbedParser(rootDocument, context));

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -346,17 +346,9 @@ public class Extractor {
         long before = currentTimeMillis();
         TikaDocument document = extract(path);
         logger.info("{} extracted in {}ms", path, currentTimeMillis() - before);
-        try {
-            spewer.write(document);
-        } finally {
-            // The spew walk has read the whole tree by now, so closing the root reader is safe.
-            // This is the end-of-extraction signal that releases any embed-text temp files spilled
-            // past the in-memory budget (see ResourceClosingReader); without it they would leak.
-            final Reader reader = document.getReader();
-            if (null != reader) {
-                reader.close();
-            }
-        }
+        // Spewer.write() walks the whole tree and closes every document reader (including the
+        // root, which releases any spilled embed-text temp files), so no cleanup is needed here.
+        spewer.write(document);
     }
 
     /**

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -90,6 +90,9 @@ import static org.icij.extract.extractor.ArtifactUtils.getEmbeddedPath;
         ". Defaults to 12 hours.", parameter = "duration")
 @Option(name = "ocr", description = "Enable or disable automatic OCR. On by default.")
 @Option(name = "ocrType", description = "Name of the OCR to use TESSERACT, TESS4J")
+@Option(name = "embedMemoryBudgetMb", description = "Maximum megabytes of embedded-document " +
+        "extracted text to hold in memory before overflowing to temp files. Defaults to 512.",
+        parameter = "megabytes")
 public class Extractor {
 
     public static final String PAGES_JSON = "pages.json";
@@ -126,6 +129,7 @@ public class Extractor {
     private OutputFormat outputFormat = OutputFormat.TEXT;
     private EmbedHandling embedHandling = EmbedHandling.getDefault();
     private Path embedOutput = null;
+    private long embedMemoryBudgetBytes = 512L * 1024 * 1024;
 
     /**
      * Create a new extractor, which will OCR images by default if Tesseract is available locally, extract inline
@@ -177,6 +181,8 @@ public class Extractor {
         options.get("ocrLanguage", "eng").value().ifPresent(this::setOcrLanguage);
         options.get("ocrTimeout", "12h").parse().asDuration().ifPresent(this::setOcrTimeout);
         options.valueIfPresent("embedOutput").ifPresent(embedOutput -> setEmbedOutputPath(Paths.get(embedOutput)));
+        options.get("embedMemoryBudgetMb", "512").parse().asInteger()
+                .ifPresent(mb -> setEmbedMemoryBudgetBytes(mb * 1024L * 1024L));
 
         String algorithm = options.valueIfPresent("digestAlgorithm").orElse("SHA-256");
         setDigestAlgorithm(algorithm);
@@ -255,6 +261,14 @@ public class Extractor {
      */
     public Path getEmbedOutputPath() {
         return embedOutput;
+    }
+
+    public long getEmbedMemoryBudgetBytes() {
+        return embedMemoryBudgetBytes;
+    }
+
+    public void setEmbedMemoryBudgetBytes(final long embedMemoryBudgetBytes) {
+        this.embedMemoryBudgetBytes = embedMemoryBudgetBytes;
     }
 
     /**

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -9,6 +9,7 @@ import org.apache.tika.exception.EncryptedDocumentException;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.DocumentSelector;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
+import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.CompositeParser;
@@ -37,7 +38,6 @@ import org.icij.extract.parser.CacheParserDecorator;
 import org.icij.extract.parser.FallbackParser;
 import org.icij.extract.parser.HTML5Serializer;
 import org.icij.extract.parser.ParsingReaderWithContentHandler;
-import org.apache.tika.io.TemporaryResources;
 import org.icij.extract.parser.ResourceClosingReader;
 import org.icij.extract.parser.ResilientOutlookPSTParser;
 import org.icij.extract.report.Reporter;
@@ -578,14 +578,24 @@ public class Extractor {
             context.set(EmbeddedDocumentExtractor.class, new EmbedBlocker());
         }
 
-        Reader reader = new ParsingReaderWithContentHandler(parser, tikaInputStream, rootDocument.getMetadata(), context, handlerProvider);
-        if (null != embedTextResources) {
-            // Delete spilled embed-text temp files when the root reader is closed.
-            reader = new ResourceClosingReader(reader, embedTextResources);
+        try {
+            Reader reader = new ParsingReaderWithContentHandler(parser, tikaInputStream, rootDocument.getMetadata(), context, handlerProvider);
+            if (null != embedTextResources) {
+                // Delete spilled embed-text temp files when the root reader is closed.
+                reader = new ResourceClosingReader(reader, embedTextResources);
+            }
+            rootDocument.setReader(reader);
+            return rootDocument;
+        } catch (final Exception e) {
+            if (null != embedTextResources) {
+                try {
+                    embedTextResources.close();
+                } catch (final IOException suppressed) {
+                    e.addSuppressed(suppressed);
+                }
+            }
+            throw e;
         }
-        rootDocument.setReader(reader);
-
-        return rootDocument;
     }
 
     private void excludeParser(final Class<? extends Parser> exclude) {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/MemoryPressureGauge.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/MemoryPressureGauge.java
@@ -1,0 +1,100 @@
+package org.icij.extract.extractor;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
+import java.util.Locale;
+import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+
+/**
+ * Reports whether the JVM heap is under memory pressure, used to make embedded-text buffering spill
+ * to disk early — before a fixed byte budget would — so extraction of very large containers (PSTs,
+ * mailboxes) stays within whatever heap is available regardless of how big the document tree grows.
+ *
+ * <p>The signal is the post-GC usage ratio of the tenured/old-generation heap pool, which approximates
+ * the live working set rather than transient garbage. Sampling is throttled (the value is cached for a
+ * short interval) because the check sits on the per-write hot path. A threshold outside the open
+ * interval (0, 1) disables the gauge entirely, falling back to pure byte-budget behaviour.
+ */
+class MemoryPressureGauge implements BooleanSupplier {
+
+    private final double threshold;
+    private final DoubleSupplier usageRatio;
+    private final long sampleIntervalNanos;
+
+    private boolean sampled = false;
+    private long lastSampleNanos = 0L;
+    private boolean cachedHigh = false;
+
+    MemoryPressureGauge(final double threshold) {
+        this(threshold, defaultRatioSupplier(), 100_000_000L); // sample at most every 100ms
+    }
+
+    /** Test seam: inject the usage ratio and sample interval. */
+    MemoryPressureGauge(final double threshold, final DoubleSupplier usageRatio, final long sampleIntervalNanos) {
+        this.threshold = threshold;
+        this.usageRatio = usageRatio;
+        this.sampleIntervalNanos = sampleIntervalNanos;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        // A threshold outside (0, 1) disables adaptive spilling.
+        if (!(threshold > 0.0 && threshold < 1.0)) {
+            return false;
+        }
+        final long now = System.nanoTime();
+        if (!sampled || now - lastSampleNanos >= sampleIntervalNanos) {
+            cachedHigh = usageRatio.getAsDouble() >= threshold;
+            lastSampleNanos = now;
+            sampled = true;
+        }
+        return cachedHigh;
+    }
+
+    private static DoubleSupplier defaultRatioSupplier() {
+        final MemoryPoolMXBean pool = findHeapPool();
+        return () -> {
+            if (null == pool) {
+                return 0.0;
+            }
+            // Prefer collection usage (state right after the last GC of this pool): it reflects the
+            // live set rather than not-yet-collected garbage, so we don't spill on collectable bytes.
+            MemoryUsage usage = pool.getCollectionUsage();
+            if (null == usage || usage.getMax() <= 0) {
+                usage = pool.getUsage();
+            }
+            if (null == usage || usage.getMax() <= 0) {
+                return 0.0;
+            }
+            return (double) usage.getUsed() / (double) usage.getMax();
+        };
+    }
+
+    /**
+     * The tenured/old-generation heap pool for generational collectors, or the largest heap pool for
+     * region/single-space collectors (G1 old gen, ZGC's ZHeap, Shenandoah). Null if none is exposed.
+     */
+    private static MemoryPoolMXBean findHeapPool() {
+        MemoryPoolMXBean fallback = null;
+        long largestMax = -1;
+        for (final MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
+            if (pool.getType() != MemoryType.HEAP) {
+                continue;
+            }
+            final String name = pool.getName().toLowerCase(Locale.ROOT);
+            if (name.contains("old") || name.contains("tenured")) {
+                return pool;
+            }
+            final MemoryUsage usage = pool.getUsage();
+            final long max = null != usage ? usage.getMax() : -1;
+            if (max > largestMax) {
+                largestMax = max;
+                fallback = pool;
+            }
+        }
+        return fallback;
+    }
+}

--- a/extract-lib/src/main/java/org/icij/extract/extractor/MemoryPressureGauge.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/MemoryPressureGauge.java
@@ -41,12 +41,13 @@ class MemoryPressureGauge implements BooleanSupplier {
 
     @Override
     public boolean getAsBoolean() {
-        // A threshold outside (0, 1) disables adaptive spilling.
-        if (!(threshold > 0.0 && threshold < 1.0)) {
+        // A threshold outside (0, 1) disables adaptive spilling: fall back to pure byte-budget behaviour.
+        if (!adaptiveSpillingEnabled()) {
             return false;
         }
+        // The result is cached between samples because this check sits on the per-write hot path.
         final long now = System.nanoTime();
-        if (!sampled || now - lastSampleNanos >= sampleIntervalNanos) {
+        if (shouldResample(now)) {
             cachedHigh = usageRatio.getAsDouble() >= threshold;
             lastSampleNanos = now;
             sampled = true;
@@ -54,23 +55,33 @@ class MemoryPressureGauge implements BooleanSupplier {
         return cachedHigh;
     }
 
+    private boolean adaptiveSpillingEnabled() {
+        return threshold > 0.0 && threshold < 1.0;
+    }
+
+    private boolean shouldResample(final long now) {
+        return !sampled || now - lastSampleNanos >= sampleIntervalNanos;
+    }
+
     private static DoubleSupplier defaultRatioSupplier() {
-        final MemoryPoolMXBean pool = findHeapPool();
-        return () -> {
-            if (null == pool) {
-                return 0.0;
-            }
-            // Prefer collection usage (state right after the last GC of this pool): it reflects the
-            // live set rather than not-yet-collected garbage, so we don't spill on collectable bytes.
-            MemoryUsage usage = pool.getCollectionUsage();
-            if (null == usage || usage.getMax() <= 0) {
-                usage = pool.getUsage();
-            }
-            if (null == usage || usage.getMax() <= 0) {
-                return 0.0;
-            }
-            return (double) usage.getUsed() / (double) usage.getMax();
-        };
+        final MemoryPoolMXBean oldGenerationPool = findHeapPool();
+        return () -> heapUsageRatio(oldGenerationPool);
+    }
+
+    private static double heapUsageRatio(final MemoryPoolMXBean pool) {
+        if (null == pool) {
+            return 0.0;
+        }
+        // Prefer collection usage (the state right after this pool's last GC): it reflects the live set
+        // rather than not-yet-collected garbage, so we don't spill on merely collectable bytes.
+        MemoryUsage usage = pool.getCollectionUsage();
+        if (null == usage || usage.getMax() <= 0) {
+            usage = pool.getUsage();
+        }
+        if (null == usage || usage.getMax() <= 0) {
+            return 0.0;
+        }
+        return (double) usage.getUsed() / (double) usage.getMax();
     }
 
     /**

--- a/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
+++ b/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
@@ -288,6 +288,12 @@ public class ResilientOutlookPSTParser implements Parser {
         if (failed > 0) {
             logger.warn("PST email loss in \"{}\": expected {} messages, emitted {} ({} failed).",
                     pstPath, expected, emittedCount, failed);
+        } else if (emittedCount > expected) {
+            // Not loss, but the ground-truth baseline was exceeded (orphan recovery surfaced messages
+            // outside the enumerated folder tree, or the descriptor count under-enumerated). Surface it
+            // rather than letting the clamped failed=0 read as a clean, fully-reconciled extraction.
+            logger.warn("PST count mismatch in \"{}\": emitted {} messages, more than the {} enumerated "
+                    + "descriptors; loss accounting may be incomplete.", pstPath, emittedCount, expected);
         }
     }
 

--- a/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
+++ b/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
@@ -99,6 +99,9 @@ public class ResilientOutlookPSTParser implements Parser {
     private PSTFile openPstFile(final String pstPath) throws Exception {
         final PSTFile pstFile = new PSTFile(pstPath);
         if (pstFile.getPSTFileType() == PSTFile.PST_TYPE_2013_UNICODE) {
+            // new PSTFile already opened the underlying file handle; release it before bailing
+            // out, otherwise every unsupported (OST 2013) file leaks a descriptor.
+            closeQuietly(pstFile);
             throw new TikaException("OST 2013 is not supported by java-libpst");
         }
         return pstFile;

--- a/extract-lib/src/main/java/org/icij/extract/parser/ResourceClosingReader.java
+++ b/extract-lib/src/main/java/org/icij/extract/parser/ResourceClosingReader.java
@@ -1,0 +1,30 @@
+package org.icij.extract.parser;
+
+import java.io.Closeable;
+import java.io.FilterReader;
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * A {@link Reader} that closes an additional {@link Closeable} resource when it is closed.
+ * Used to tie the lifetime of an extraction's spilled embed-text temp files to the
+ * close() of the root document reader, which is the universal end-of-extraction signal.
+ */
+public class ResourceClosingReader extends FilterReader {
+
+    private final Closeable resource;
+
+    public ResourceClosingReader(final Reader in, final Closeable resource) {
+        super(in);
+        this.resource = resource;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            super.close();
+        } finally {
+            resource.close();
+        }
+    }
+}

--- a/extract-lib/src/main/java/org/icij/extract/parser/ResourceClosingReader.java
+++ b/extract-lib/src/main/java/org/icij/extract/parser/ResourceClosingReader.java
@@ -13,6 +13,7 @@ import java.io.Reader;
 public class ResourceClosingReader extends FilterReader {
 
     private final Closeable resource;
+    private boolean closed = false;
 
     public ResourceClosingReader(final Reader in, final Closeable resource) {
         super(in);
@@ -21,6 +22,12 @@ public class ResourceClosingReader extends FilterReader {
 
     @Override
     public void close() throws IOException {
+        // Idempotent: the spew walk and a caller's own try-with-resources may both close this,
+        // and the underlying parsing reader does not tolerate a second close.
+        if (closed) {
+            return;
+        }
+        closed = true;
         try {
             super.close();
         } finally {

--- a/extract-lib/src/main/java/org/icij/spewer/RESTSpewer.java
+++ b/extract-lib/src/main/java/org/icij/spewer/RESTSpewer.java
@@ -34,19 +34,24 @@ public class RESTSpewer extends Spewer implements Serializable {
 
 	@Override
 	public void write(final TikaDocument tikaDocument) throws IOException {
-		final HttpPut put = new HttpPut(uri.resolve(tikaDocument.getId()));
-		final List<NameValuePair> params = new ArrayList<>();
+		try {
+			final HttpPut put = new HttpPut(uri.resolve(tikaDocument.getId()));
+			final List<NameValuePair> params = new ArrayList<>();
 
-		params.add(new BasicNameValuePair(fields.forId(), tikaDocument.getId()));
-		params.add(new BasicNameValuePair(fields.forPath(), tikaDocument.getPath().toString()));
-		params.add(new BasicNameValuePair(fields.forText(), toString(tikaDocument.getReader())));
+			params.add(new BasicNameValuePair(fields.forId(), tikaDocument.getId()));
+			params.add(new BasicNameValuePair(fields.forPath(), tikaDocument.getPath().toString()));
+			params.add(new BasicNameValuePair(fields.forText(), toString(tikaDocument.getReader())));
 
-		if (outputMetadata) {
-			parametrizeMetadata(tikaDocument.getMetadata(), params);
+			if (outputMetadata) {
+				parametrizeMetadata(tikaDocument.getMetadata(), params);
+			}
+
+			put.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+			put(put);
+		} finally {
+			// Release the root reader (and any spilled embed-text temp files it owns).
+			closeReaderQuietly(tikaDocument);
 		}
-
-		put.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
-		put(put);
 	}
 
 	public void writeMetadata(final TikaDocument tikaDocument) throws IOException {

--- a/extract-lib/src/main/java/org/icij/spewer/Spewer.java
+++ b/extract-lib/src/main/java/org/icij/spewer/Spewer.java
@@ -57,18 +57,45 @@ public abstract class Spewer implements AutoCloseable, Serializable {
     protected abstract void writeDocument(TikaDocument doc, TikaDocument parent, TikaDocument root, int level) throws IOException;
 
     public void write(final TikaDocument document) throws IOException {
-        writeDocument(document, null, null, 0);
-        for (EmbeddedTikaDocument childDocument : document.getEmbeds()) {
-            writeTree(childDocument, document, document, 1);
+        try {
+            writeDocument(document, null, null, 0);
+            for (EmbeddedTikaDocument childDocument : document.getEmbeds()) {
+                writeTree(childDocument, document, document, 1);
+            }
+        } finally {
+            // Closing the root reader releases any embedded-text temp files spilled past the
+            // in-memory budget (see ResourceClosingReader). Owning cleanup here means every
+            // spewer benefits, not just one Extractor entry point.
+            closeReaderQuietly(document);
         }
     }
 
     private void writeTree(final TikaDocument doc, final TikaDocument parent, TikaDocument root, final int level)
             throws IOException {
-        writeDocument(doc, parent, root, level);
+        try {
+            writeDocument(doc, parent, root, level);
 
-        for (EmbeddedTikaDocument child : doc.getEmbeds()) {
-            writeTree(child, doc, root, level + 1);
+            for (EmbeddedTikaDocument child : doc.getEmbeds()) {
+                writeTree(child, doc, root, level + 1);
+            }
+        } finally {
+            // Release this embedded document's reader as soon as its subtree is written. When its
+            // text spilled to disk the reader is an open file handle; without this a large container
+            // (PST/mailbox with tens of thousands of items) holds them all open at once and exhausts
+            // the process file-descriptor limit.
+            closeReaderQuietly(doc);
+        }
+    }
+
+    protected static void closeReaderQuietly(final TikaDocument document) {
+        try {
+            final Reader reader = document.getReader();
+            if (null != reader) {
+                reader.close();
+            }
+        } catch (final IOException e) {
+            // Best-effort: the content has already been written, so a failed close must not
+            // mask the write outcome.
         }
     }
 

--- a/extract-lib/src/test/java/org/icij/extract/extractor/BudgetedEmbedBufferTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/BudgetedEmbedBufferTest.java
@@ -72,6 +72,32 @@ public class BudgetedEmbedBufferTest {
     }
 
     @Test
+    public void testSpillsUnderMemoryPressureEvenWhenUnderByteBudget() throws Exception {
+        AtomicLong reserved = new AtomicLong();
+        // Huge byte budget so only memory pressure can trigger the spill.
+        BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, Long.MAX_VALUE, tmp, () -> true);
+
+        buffer.write("hello".getBytes(StandardCharsets.UTF_8));
+        buffer.close();
+
+        assertThat(buffer.isSpilled()).isTrue();
+        assertThat(reserved.get()).isEqualTo(0L);
+        assertThat(read(buffer.readerGenerator())).isEqualTo("hello");
+    }
+
+    @Test
+    public void testStaysInMemoryWhenNoPressureAndUnderBudget() throws Exception {
+        AtomicLong reserved = new AtomicLong();
+        BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, Long.MAX_VALUE, tmp, () -> false);
+
+        buffer.write("hello".getBytes(StandardCharsets.UTF_8));
+        buffer.close();
+
+        assertThat(buffer.isSpilled()).isFalse();
+        assertThat(read(buffer.readerGenerator())).isEqualTo("hello");
+    }
+
+    @Test
     public void testDiscardReleasesReservedBytes() throws Exception {
         AtomicLong reserved = new AtomicLong();
         BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, 1024, tmp);

--- a/extract-lib/src/test/java/org/icij/extract/extractor/BudgetedEmbedBufferTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/BudgetedEmbedBufferTest.java
@@ -98,6 +98,20 @@ public class BudgetedEmbedBufferTest {
     }
 
     @Test
+    public void testDiscardAfterSpillReleasesStreamWithoutError() throws Exception {
+        AtomicLong reserved = new AtomicLong();
+        BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, 0, tmp); // 0 budget => spills immediately
+
+        buffer.write("spilled".getBytes(StandardCharsets.UTF_8));
+        assertThat(buffer.isSpilled()).isTrue();
+
+        buffer.discard();       // must release the open spill stream, not leak it
+        buffer.close();         // must remain safe after discard
+
+        assertThat(reserved.get()).isEqualTo(0L);
+    }
+
+    @Test
     public void testDiscardReleasesReservedBytes() throws Exception {
         AtomicLong reserved = new AtomicLong();
         BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, 1024, tmp);

--- a/extract-lib/src/test/java/org/icij/extract/extractor/BudgetedEmbedBufferTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/BudgetedEmbedBufferTest.java
@@ -1,0 +1,113 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.io.TemporaryResources;
+import org.icij.extract.document.TikaDocument.ReaderGenerator;
+import org.icij.spewer.Spewer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class BudgetedEmbedBufferTest {
+
+    private TemporaryResources tmp;
+
+    @Before public void setUp() { tmp = new TemporaryResources(); }
+    @After public void tearDown() throws Exception { tmp.close(); }
+
+    private static String read(ReaderGenerator generator) throws Exception {
+        try (Reader reader = generator.generate()) {
+            return Spewer.toString(reader);
+        }
+    }
+
+    @Test
+    public void testStaysInMemoryUnderBudget() throws Exception {
+        AtomicLong reserved = new AtomicLong();
+        BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, 1024, tmp);
+
+        buffer.write("hello".getBytes(StandardCharsets.UTF_8));
+        buffer.close();
+
+        assertThat(buffer.isSpilled()).isFalse();
+        assertThat(reserved.get()).isEqualTo(5L);
+        assertThat(read(buffer.readerGenerator())).isEqualTo("hello");
+    }
+
+    @Test
+    public void testSpillsWhenSingleWriteExceedsBudget() throws Exception {
+        AtomicLong reserved = new AtomicLong();
+        BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, 4, tmp);
+
+        buffer.write("hello world".getBytes(StandardCharsets.UTF_8));
+        buffer.close();
+
+        assertThat(buffer.isSpilled()).isTrue();
+        assertThat(reserved.get()).isEqualTo(0L); // nothing left resident in memory
+        assertThat(read(buffer.readerGenerator())).isEqualTo("hello world");
+    }
+
+    @Test
+    public void testSharedBudgetForcesLaterBufferToSpill() throws Exception {
+        AtomicLong reserved = new AtomicLong();
+
+        BudgetedEmbedBuffer first = new BudgetedEmbedBuffer(reserved, 8, tmp);
+        first.write("12345678".getBytes(StandardCharsets.UTF_8)); // exactly fills the budget
+        first.close();
+        assertThat(first.isSpilled()).isFalse();
+
+        BudgetedEmbedBuffer second = new BudgetedEmbedBuffer(reserved, 8, tmp);
+        second.write("9".getBytes(StandardCharsets.UTF_8)); // would exceed -> spills
+        second.close();
+
+        assertThat(second.isSpilled()).isTrue();
+        assertThat(read(first.readerGenerator())).isEqualTo("12345678");
+        assertThat(read(second.readerGenerator())).isEqualTo("9");
+    }
+
+    @Test
+    public void testDiscardReleasesReservedBytes() throws Exception {
+        AtomicLong reserved = new AtomicLong();
+        BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, 1024, tmp);
+
+        buffer.write("hello".getBytes(StandardCharsets.UTF_8));
+        assertThat(reserved.get()).isEqualTo(5L);
+
+        buffer.discard();
+        assertThat(reserved.get()).isEqualTo(0L);
+    }
+
+    @Test
+    public void testWriteAfterCloseThrows() throws Exception {
+        AtomicLong reserved = new AtomicLong();
+        BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, 1024, tmp);
+        buffer.close();
+        try {
+            buffer.write("x".getBytes(StandardCharsets.UTF_8));
+            org.junit.Assert.fail("expected IOException");
+        } catch (IOException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testReaderGeneratorThrowsAfterDiscard() throws Exception {
+        AtomicLong reserved = new AtomicLong();
+        BudgetedEmbedBuffer buffer = new BudgetedEmbedBuffer(reserved, 1024, tmp);
+        buffer.write("hello".getBytes(StandardCharsets.UTF_8));
+        buffer.discard();
+        org.icij.extract.document.TikaDocument.ReaderGenerator generator = buffer.readerGenerator();
+        try {
+            generator.generate();
+            org.junit.Assert.fail("expected IOException");
+        } catch (IOException expected) {
+            // expected
+        }
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
@@ -567,6 +567,19 @@ public class ExtractorTest {
 		assertThat(extractor.ocrConfig.getParserClass()).isEqualTo(Tess4JOCRParser.class);
 	}
 
+	@Test
+	public void testEmbedMemoryBudgetDefaultsTo512Mb() {
+		Extractor extractor = new Extractor();
+		assertThat(extractor.getEmbedMemoryBudgetBytes()).isEqualTo(512L * 1024 * 1024);
+	}
+
+	@Test
+	public void testEmbedMemoryBudgetOptionParsedFromMegabytes() {
+		Options<String> options = Options.from(Map.of("embedMemoryBudgetMb", "2"));
+		Extractor extractor = new Extractor(options);
+		assertThat(extractor.getEmbedMemoryBudgetBytes()).isEqualTo(2L * 1024 * 1024);
+	}
+
 	private String getExpected(final String file) throws IOException {
 		try (final Reader input = new InputStreamReader(getClass().getResourceAsStream(file), StandardCharsets.UTF_8)) {
 			return Spewer.toString(input);

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
@@ -589,6 +589,18 @@ public class ExtractorTest {
 		assertThat(spilled).contains("level1");             // sanity: real embed content present
 	}
 
+	@Test
+	public void testNormalArchiveDoesNotSpillUnderDefaultBudget() throws Exception {
+		Extractor extractor = aBasicExtractor();
+		extractor.disableOcr();
+		// default 512MB budget: a tiny archive must read back fine with no error
+		TikaDocument doc = extractDocument(extractor, "/documents/embedded_with_duplicate.tgz");
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		new PrintStreamSpewer(new PrintStream(out, true, StandardCharsets.UTF_8.name()), new FieldNames()).write(doc);
+		doc.getReader().close();
+		assertThat(out.toString(StandardCharsets.UTF_8)).contains("level1");
+	}
+
 	private String spewTreeText(final long budgetBytes) throws Exception {
 		Extractor extractor = aBasicExtractor();
 		extractor.disableOcr();

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
@@ -44,6 +44,7 @@ import java.util.stream.Stream;
 
 import static java.lang.Math.toIntExact;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 import static org.icij.extract.ocr.OCRParser.OCR_PARSER;
 import static org.icij.extract.ocr.ParserWithConfidence.OCR_CONFIDENCE;
 
@@ -396,6 +397,38 @@ public class ExtractorTest {
 		try (Stream<Path> files = Files.list(tmp)) {
 			return files.filter(p -> p.getFileName().toString().startsWith("apache-tika-"))
 					.collect(Collectors.toSet());
+		}
+	}
+
+	@Test
+	public void testSpilledEmbedReadersDoNotLeakFileDescriptors() throws Exception {
+		// Each spilled embed's reader is an open file handle; if the spew walk doesn't close them
+		// they stay open (cached on each TikaDocument) until GC, exhausting the fd limit on large
+		// containers. Count fds pointing at apache-tika temp files before vs after a forced-spill spew.
+		assumeTrue("requires /proc/self/fd (Linux)", Files.isDirectory(Paths.get("/proc/self/fd")));
+		Extractor extractor = aBasicExtractor();
+		extractor.disableOcr();
+		extractor.setEmbedOutputPath(folder.newFolder("embeds").toPath());
+		extractor.setEmbedMemoryBudgetBytes(0L); // force every embed to spill
+
+		long before = openTikaTempFds();
+		extractor.extract(
+				Paths.get(getClass().getResource("/documents/recursive_embedded.docx").getPath()),
+				new PrintStreamSpewer(new PrintStream(OutputStream.nullOutputStream()), new FieldNames()));
+		long after = openTikaTempFds();
+
+		assertThat(after).isEqualTo(before);
+	}
+
+	private static long openTikaTempFds() throws IOException {
+		try (Stream<Path> fds = Files.list(Paths.get("/proc/self/fd"))) {
+			return fds.filter(fd -> {
+				try {
+					return Files.readSymbolicLink(fd).toString().contains("apache-tika");
+				} catch (IOException e) {
+					return false;
+				}
+			}).count();
 		}
 	}
 

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
@@ -33,9 +34,13 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.Math.toIntExact;
 import static org.fest.assertions.Assertions.assertThat;
@@ -366,6 +371,35 @@ public class ExtractorTest {
 	}
 
 	@Test
+	public void testEmbedTextSpillFilesAreCleanedUpAfterSpew() throws Exception {
+		// GIVEN an extractor forced to spill every embedded document's text to disk
+		Extractor extractor = aBasicExtractor();
+		extractor.disableOcr();
+		extractor.setEmbedOutputPath(folder.newFolder("embeds").toPath());
+		extractor.setEmbedMemoryBudgetBytes(0L); // 0 budget => first embed write spills to a temp file
+
+		Set<Path> before = tikaTempFiles();
+
+		// WHEN extracting through the spewer path (as DocumentConsumer / Datashare do)
+		extractor.extract(
+				Paths.get(getClass().getResource("/documents/recursive_embedded.docx").getPath()),
+				new PrintStreamSpewer(new PrintStream(OutputStream.nullOutputStream()), new FieldNames()));
+
+		// THEN the spilled temp files do not leak once the extraction is finished
+		Set<Path> leaked = tikaTempFiles();
+		leaked.removeAll(before);
+		assertThat(new ArrayList<>(leaked)).isEmpty();
+	}
+
+	private static Set<Path> tikaTempFiles() throws IOException {
+		Path tmp = Paths.get(System.getProperty("java.io.tmpdir"));
+		try (Stream<Path> files = Files.list(tmp)) {
+			return files.filter(p -> p.getFileName().toString().startsWith("apache-tika-"))
+					.collect(Collectors.toSet());
+		}
+	}
+
+	@Test
 	public void testEmbeddedWithDuplicates() throws Exception {
         //GIVEN
         Extractor extractor = aBasicExtractor();
@@ -568,9 +602,21 @@ public class ExtractorTest {
 	}
 
 	@Test
-	public void testEmbedMemoryBudgetDefaultsTo512Mb() {
+	public void testEmbedMemoryBudgetDefaultsTo64Mb() {
 		Extractor extractor = new Extractor();
-		assertThat(extractor.getEmbedMemoryBudgetBytes()).isEqualTo(512L * 1024 * 1024);
+		assertThat(extractor.getEmbedMemoryBudgetBytes()).isEqualTo(64L * 1024 * 1024);
+	}
+
+	@Test
+	public void testEmbedMemoryPressureThresholdDefaultsTo07() {
+		Extractor extractor = new Extractor();
+		assertThat(extractor.getEmbedMemoryPressureThreshold()).isEqualTo(0.7);
+	}
+
+	@Test
+	public void testEmbedMemoryPressureThresholdOptionParsed() {
+		Extractor extractor = new Extractor(Options.from(Map.of("embedMemoryPressureThreshold", "0.5")));
+		assertThat(extractor.getEmbedMemoryPressureThreshold()).isEqualTo(0.5);
 	}
 
 	@Test
@@ -582,7 +628,7 @@ public class ExtractorTest {
 
 	@Test
 	public void testEmbedTextIsIdenticalWhetherSpilledOrInMemory() throws Exception {
-		String inMemory = spewTreeText(512L * 1024 * 1024); // default budget: nothing spills
+		String inMemory = spewTreeText(512L * 1024 * 1024); // large budget: nothing spills
 		String spilled = spewTreeText(1L);                  // 1-byte budget: everything spills
 
 		assertThat(spilled).isEqualTo(inMemory);
@@ -593,7 +639,7 @@ public class ExtractorTest {
 	public void testNormalArchiveDoesNotSpillUnderDefaultBudget() throws Exception {
 		Extractor extractor = aBasicExtractor();
 		extractor.disableOcr();
-		// default 512MB budget: a tiny archive must read back fine with no error
+		// default budget: a tiny archive must read back fine with no error
 		TikaDocument doc = extractDocument(extractor, "/documents/embedded_with_duplicate.tgz");
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		new PrintStreamSpewer(new PrintStream(out, true, StandardCharsets.UTF_8.name()), new FieldNames()).write(doc);

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
@@ -580,6 +580,29 @@ public class ExtractorTest {
 		assertThat(extractor.getEmbedMemoryBudgetBytes()).isEqualTo(2L * 1024 * 1024);
 	}
 
+	@Test
+	public void testEmbedTextIsIdenticalWhetherSpilledOrInMemory() throws Exception {
+		String inMemory = spewTreeText(512L * 1024 * 1024); // default budget: nothing spills
+		String spilled = spewTreeText(1L);                  // 1-byte budget: everything spills
+
+		assertThat(spilled).isEqualTo(inMemory);
+		assertThat(spilled).contains("level1");             // sanity: real embed content present
+	}
+
+	private String spewTreeText(final long budgetBytes) throws Exception {
+		Extractor extractor = aBasicExtractor();
+		extractor.disableOcr();
+		extractor.setEmbedMemoryBudgetBytes(budgetBytes);
+
+		TikaDocument doc = extractDocument(extractor, "/documents/embedded_with_duplicate.tgz");
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		PrintStreamSpewer spewer = new PrintStreamSpewer(new PrintStream(out, true, StandardCharsets.UTF_8.name()), new FieldNames());
+		spewer.outputMetadata(false); // exclude non-deterministic metadata (temp file names, timestamps)
+		spewer.write(doc);
+		doc.getReader().close(); // triggers ResourceClosingReader cleanup of any temp files
+		return out.toString(StandardCharsets.UTF_8);
+	}
+
 	private String getExpected(final String file) throws IOException {
 		try (final Reader input = new InputStreamReader(getClass().getResourceAsStream(file), StandardCharsets.UTF_8)) {
 			return Spewer.toString(input);

--- a/extract-lib/src/test/java/org/icij/extract/extractor/MemoryPressureGaugeTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/MemoryPressureGaugeTest.java
@@ -1,0 +1,55 @@
+package org.icij.extract.extractor;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.DoubleSupplier;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class MemoryPressureGaugeTest {
+
+    @Test
+    public void testHighWhenRatioMeetsThreshold() {
+        MemoryPressureGauge gauge = new MemoryPressureGauge(0.7, () -> 0.8, 0L);
+        assertThat(gauge.getAsBoolean()).isTrue();
+    }
+
+    @Test
+    public void testLowWhenRatioBelowThreshold() {
+        MemoryPressureGauge gauge = new MemoryPressureGauge(0.7, () -> 0.5, 0L);
+        assertThat(gauge.getAsBoolean()).isFalse();
+    }
+
+    @Test
+    public void testDisabledWhenThresholdNotInOpenUnitInterval() {
+        assertThat(new MemoryPressureGauge(0.0, () -> 1.0, 0L).getAsBoolean()).isFalse();
+        assertThat(new MemoryPressureGauge(1.0, () -> 1.0, 0L).getAsBoolean()).isFalse();
+        assertThat(new MemoryPressureGauge(-1.0, () -> 1.0, 0L).getAsBoolean()).isFalse();
+    }
+
+    @Test
+    public void testSampleIsCachedWithinInterval() {
+        AtomicInteger calls = new AtomicInteger();
+        DoubleSupplier ratio = () -> { calls.incrementAndGet(); return 0.9; };
+        // Huge interval => only the first call samples; the rest return the cached value.
+        MemoryPressureGauge gauge = new MemoryPressureGauge(0.7, ratio, Long.MAX_VALUE);
+
+        assertThat(gauge.getAsBoolean()).isTrue();
+        assertThat(gauge.getAsBoolean()).isTrue();
+        assertThat(gauge.getAsBoolean()).isTrue();
+        assertThat(calls.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void testResamplesEveryCallWhenIntervalZero() {
+        AtomicInteger calls = new AtomicInteger();
+        // Ratio crosses the threshold on the third sample.
+        DoubleSupplier ratio = () -> calls.incrementAndGet() >= 3 ? 0.9 : 0.1;
+        MemoryPressureGauge gauge = new MemoryPressureGauge(0.7, ratio, 0L);
+
+        assertThat(gauge.getAsBoolean()).isFalse();
+        assertThat(gauge.getAsBoolean()).isFalse();
+        assertThat(gauge.getAsBoolean()).isTrue();
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/parser/ResourceClosingReaderTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/parser/ResourceClosingReaderTest.java
@@ -1,0 +1,31 @@
+package org.icij.extract.parser;
+
+import org.junit.Test;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ResourceClosingReaderTest {
+
+    @Test
+    public void testClosesExtraResourceOnClose() throws Exception {
+        AtomicBoolean resourceClosed = new AtomicBoolean(false);
+        Reader reader = new ResourceClosingReader(new StringReader("hi"), () -> resourceClosed.set(true));
+
+        assertThat(resourceClosed.get()).isFalse();
+        reader.close();
+        assertThat(resourceClosed.get()).isTrue();
+    }
+
+    @Test
+    public void testStillReadsThroughDelegate() throws Exception {
+        try (Reader reader = new ResourceClosingReader(new StringReader("hi"), () -> {})) {
+            assertThat((char) reader.read()).isEqualTo('h');
+            assertThat((char) reader.read()).isEqualTo('i');
+            assertThat(reader.read()).isEqualTo(-1);
+        }
+    }
+}

--- a/extract-lib/src/test/java/org/icij/spewer/SpewerClosesReadersTest.java
+++ b/extract-lib/src/test/java/org/icij/spewer/SpewerClosesReadersTest.java
@@ -1,0 +1,75 @@
+package org.icij.spewer;
+
+import org.apache.tika.metadata.Metadata;
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.EmbeddedTikaDocument;
+import org.icij.extract.document.TikaDocument;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * The spew walk must close every document's reader (root and all embeds). Spilled embed readers are
+ * open file handles, so leaving them open exhausts the process file-descriptor limit on large
+ * containers (PST/mailbox with tens of thousands of items).
+ */
+public class SpewerClosesReadersTest {
+
+    /** A reader that records whether it was closed. */
+    private static class TrackingReader extends StringReader {
+        boolean closed = false;
+        TrackingReader(final String s) { super(s); }
+        @Override public void close() { closed = true; super.close(); }
+    }
+
+    /** A spewer that reads each document's reader exactly as the real spewers do, without closing it. */
+    private static class ReadingSpewer extends Spewer {
+        ReadingSpewer() { super(new FieldNames()); }
+        @Override protected void writeDocument(TikaDocument doc, TikaDocument parent, TikaDocument root, int level) throws IOException {
+            toString(doc.getReader());
+        }
+        @Override public void close() {}
+    }
+
+    @Test
+    public void test_write_closes_every_reader_in_the_tree() throws Exception {
+        DocumentFactory factory = new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", StandardCharsets.UTF_8));
+        TikaDocument root = factory.create("root", Paths.get("root"));
+
+        List<TrackingReader> readers = new ArrayList<>();
+        TrackingReader rootReader = new TrackingReader("root body");
+        root.setReader(rootReader);
+        readers.add(rootReader);
+
+        // Two embeds, one of them nested, to cover the recursive walk.
+        EmbeddedTikaDocument e1 = root.addEmbed(new Metadata());
+        TrackingReader e1Reader = new TrackingReader("embed 1");
+        e1.setReader(e1Reader);
+        readers.add(e1Reader);
+
+        EmbeddedTikaDocument e2 = root.addEmbed(new Metadata());
+        TrackingReader e2Reader = new TrackingReader("embed 2");
+        e2.setReader(e2Reader);
+        readers.add(e2Reader);
+
+        EmbeddedTikaDocument e1a = e1.addEmbed(new Metadata());
+        TrackingReader e1aReader = new TrackingReader("embed 1a");
+        e1a.setReader(e1aReader);
+        readers.add(e1aReader);
+
+        new ReadingSpewer().write(root);
+
+        for (TrackingReader reader : readers) {
+            assertThat(reader.closed).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
This PR makes Extract able to extract very large PSTs without running out of memory or leaking system resources. It builds on the resilient PST reader already on `master` (which keeps a damaged message from aborting the whole mailbox) and focuses on the memory side: the text pulled from attachments and nested messages is now kept in memory only up to a set limit and overflows to temporary files beyond it, so memory use no longer grows with the size of the mailbox's contents.

The headline result is that a 38 GB mailbox with about 115,000 messages extracts fully in 4 GB of memory, with the number of open files staying flat no matter how much overflows to disk.

## What changed

### Memory-bounded extraction
- Each attachment or nested message's extracted text is buffered in memory against a shared limit. Once the limit is reached, further text overflows to a temporary file on disk and is read back later when the document is written out. The result is identical whether it stayed in memory or went to disk.
- As a safety net, extraction also starts overflowing to disk when the Java heap gets close to full (default 70%), even if the byte limit hasn't been reached.
- The default memory limit is 64 MB. The benchmarks below show a small limit keeps memory use low far more reliably than a large one, with no loss of speed.

Here is the path each piece of extracted text takes during an extraction:

```mermaid
flowchart TD
    A([Message or attachment]) --> B[Add its text to the shared buffer]
    B --> C{Within the memory limit<br/>and heap not near full?}
    C -->|Yes| D[Keep the text in memory]
    C -->|No| E[Overflow the text to a temporary file]
    D --> F[Write the document out]
    E --> F
    F --> G[Close its reader immediately,<br/>releasing the open file]
    G --> H{More documents?}
    H -->|Yes| A
    H -->|No| I([Delete all temporary files])
```

### Resource-safety fixes (found while testing on the large mailboxes)
- The most important one is an open-file leak. The temporary files used for overflow text were being opened and left open until garbage collection, so a large mailbox held tens of thousands of files open at once. It only survived our tests because the test machine had an unusually high open-file limit; a normal machine would hit the operating system's limit and fail. Files are now closed as soon as each document is written: on the 38 GB mailbox below, open files stayed at about 150 even while extraction created more than 86,000 overflow files.
- A couple of smaller hardening fixes so temporary-file cleanup is safe to call more than once.

### Small fixes to the existing resilient PST reader
This PR touches the resilient reader only lightly (about nine lines):
- It now closes its file handle when it rejects an unsupported (OST-2013) file, instead of leaking one per file.
- The reader records how many messages it expected versus how many it emitted. Previously an emitted-greater-than-expected result was silently treated as "no loss"; it is now logged, so an incomplete message listing is visible.

## New settings (picked up automatically by Datashare)

| Setting | Default | Meaning |
|---|---|---|
| `embedMemoryBudgetMb` | `64` | MB of attachment and embedded text kept in memory before overflowing to disk. |
| `embedMemoryPressureThreshold` | `0.7` | How full the heap can get before text starts overflowing to disk regardless of the limit above. `0` or `1` turns this off. |

No Datashare code change is needed. Just bump `extract.version` on the next release.

## Benchmark results

Four test mailboxes, codenamed Cherry (2 MB, 46 messages), Apple (8 GB, about 38,000 messages), Banana (22 GB, about 84,000 messages), and Mango (38 GB, about 115,000 messages). All run through the normal extraction path with OCR off.

### Overflowing to disk is transparent and essentially free (Cherry)
| Mode | Messages | Time | Speed | Memory used |
|---|---|---|---|---|
| In memory (default) | 46 | 0.5 s | ~86 docs/s | 64 MB |
| Forced to disk | 46 | 0.6 s | ~80 docs/s | 64 MB |

Same extracted text both ways, and about 7% slower only in the extreme case where everything overflows.

### Memory limit vs. available memory (Apple, 8 GB)
Memory use rises with the limit. A limit larger than available memory actually fails, because it fills memory before it starts overflowing. A small limit fits in a small amount of memory. Speed barely changes either way.

| limit \ available memory | 2 GB | 4 GB | 6 GB |
|---|---|---|---|
| 64 MB | ✅ | ✅ | ✅ |
| 512 MB | ❌ out of memory | ✅ | ✅ |
| 2048 MB | ❌ out of memory | ❌ out of memory | ❌ out of memory |

### Minimum memory needed (Banana, 22 GB, about 84,000 messages, 64 MB limit)
| Available memory | Result | Time |
|---|---|---|
| 8 GB | ✅ | 35.5 min |
| 5 GB | ✅ | 39 min |
| 4 GB | ✅ | 41 min |
| 3 GB | ✅ minimum | 38 min |
| 2 GB | ❌ ran out at about 75,000 of 84,000 messages | n/a |

Banana extracted all of its messages in 3 GB. The 73 damaged items that the resilient reader skips (rather than aborting on) were handled as expected at this scale, and about 9.4 GB of text overflowed across roughly 60,000 temporary files, all cleaned up afterward.

### Largest mailbox tested (Mango, 38 GB, about 115,000 messages, 64 MB limit)
| Available memory | Result | Time | Peak open files |
|---|---|---|---|
| 8 GB | ✅ | 51 min | 156 |
| 4 GB | ✅ | 68 min | 158 |

Mango extracted all 115,116 messages, with byte-identical text at both memory sizes. It overflowed about 7 GB of text across roughly 86,000 temporary files, all cleaned up afterward, and 441 damaged items were skipped without aborting. Open files stayed near 150 throughout, which confirms the leak fix at scale (the old code would have held one open file per overflowed message). 4 GB completes but runs at the edge, about 26% slower from heap pressure; 5 to 6 GB removes that penalty.

## What this does and doesn't guarantee

- Memory use is now independent of the mailbox's file size and of how much attachment text it holds, since that overflows to disk. It grows only with the number of messages, at roughly 30 to 35 KB of memory per message. As measured, 3 GB handles about 84,000 messages and 4 GB about 115,000; plan on roughly 1 GB of heap per 30,000 messages, plus headroom so the garbage collector is not running at the edge.
- This is not "any PST in 3 GB". A mailbox with many more messages needs proportionally more memory, and a single enormous attachment can still exhaust memory on its own. Removing the per-message scaling entirely would mean processing messages one at a time instead of building the whole list up front, which is a larger change, tracked separately.
- Overflowing to disk needs enough free temporary disk space, which grows with the mailbox's content.


