### PR TITLE
feat(extractor): opt-in decompressed-size guard for embedded entries

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -28,6 +28,7 @@ import org.xml.sax.SAXException;
 import org.apache.tika.parser.DigestingParser;
 
 import java.io.*;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.HashMap;
@@ -821,8 +822,11 @@ public class EmbedSpawner extends EmbedParser {
 	// True when an embed must be refused for exceeding the per-embed decompressed-size cap.
 	// maxEmbedSizeBytes <= 0 disables the guard. The size is read from Tika's Metadata.CONTENT_LENGTH,
 	// which the container parser sets to the entry's UNCOMPRESSED size for archive embeds. When the length
-	// is absent or unparseable the size is unknown: we do NOT guess and leave the embed unguarded (returning
-	// false), so streaming containers that don't report a length keep working exactly as before.
+	// is absent or genuinely non-numeric the size is unknown: we do NOT guess and leave the embed unguarded
+	// (returning false), so streaming containers that don't report a length keep working exactly as before.
+	// Parsed as a BigInteger rather than a long so a well-formed but out-of-long-range size (e.g. a crafted
+	// ZIP64 entry declaring more than Long.MAX_VALUE bytes) is treated as exceeding the cap instead of
+	// overflowing Long.parseLong and failing open on the exact attack it guards against.
 	static boolean exceedsMaxEmbedSize(final Metadata metadata, final long maxEmbedSizeBytes) {
 		if (maxEmbedSizeBytes <= 0) {
 			return false;
@@ -832,7 +836,7 @@ public class EmbedSpawner extends EmbedParser {
 			return false;
 		}
 		try {
-			return Long.parseLong(length.trim()) > maxEmbedSizeBytes;
+			return new BigInteger(length.trim()).compareTo(BigInteger.valueOf(maxEmbedSizeBytes)) > 0;
 		} catch (final NumberFormatException ignored) {
 			return false;
 		}

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -53,6 +53,13 @@ public class EmbedSpawner extends EmbedParser {
 	static final int DEFAULT_MAX_EMBED_DEPTH = 20;
 	// Metadata key set on a parent document, counting its direct children refused for exceeding the depth limit.
 	static final String EMBEDS_SKIPPED_MAX_DEPTH = "X-EXTRACT:embedsSkippedMaxDepth";
+	// Default per-embed decompressed-size cap (2 GiB): an embed whose declared decompressed size exceeds
+	// this is refused before it is spooled/recursed into (see exceedsMaxEmbedSize). Generous enough to
+	// pass any realistic single attachment while defusing the nested-zip "bomb" whose entries decompress
+	// to multi-GiB. Only enforced when the embed's size is actually known, so streaming is never broken.
+	static final long DEFAULT_MAX_EMBED_SIZE_BYTES = 2L * 1024 * 1024 * 1024;
+	// Metadata key set on a parent document, counting its direct children refused for exceeding the size cap.
+	static final String EMBEDS_SKIPPED_MAX_SIZE = "X-EXTRACT:embedsSkippedMaxSize";
 
 	private final Path outputPath;
 	private final Function<Writer, ContentHandler> handlerFunction;
@@ -69,6 +76,9 @@ public class EmbedSpawner extends EmbedParser {
 	// Pre-branch global counter, used only when legacyUntitledNaming is true.
 	private int untitledGlobalCounter = 0;
 	private final int maxEmbedDepth;
+	// Per-embed decompressed-size cap in bytes; an embed whose declared size exceeds this is refused
+	// (see exceedsMaxEmbedSize). <= 0 disables the guard.
+	private final long maxEmbedSizeBytes;
 	// Absolute nesting depth of this spawner's reseeded root within the outer document tree.
 	// 0 for the top-level spawner; a PST fan-out fork inherits the depth its shared root sat at,
 	// so the depth guard measures ABSOLUTE nesting rather than depth-relative-to-the-fork.
@@ -118,7 +128,17 @@ public class EmbedSpawner extends EmbedParser {
 				 final long embedMemoryBudgetBytes, final TemporaryResources tmp,
 				 final BooleanSupplier memoryPressureHigh, final int maxEmbedDepth) {
 		this(root, context, outputPath, handlerFunction, embedMemoryBudgetBytes, tmp, memoryPressureHigh,
-				() -> null, false, null, null, false, 0L, null, null, false, maxEmbedDepth);
+				maxEmbedDepth, DEFAULT_MAX_EMBED_SIZE_BYTES);
+	}
+
+	// Serial mode with explicit depth AND decompressed-size limits (test-friendly). No fan-out, no OCR.
+	EmbedSpawner(final TikaDocument root, final ParseContext context, final Path outputPath,
+				 final Function<Writer, ContentHandler> handlerFunction,
+				 final long embedMemoryBudgetBytes, final TemporaryResources tmp,
+				 final BooleanSupplier memoryPressureHigh, final int maxEmbedDepth,
+				 final long maxEmbedSizeBytes) {
+		this(root, context, outputPath, handlerFunction, embedMemoryBudgetBytes, tmp, memoryPressureHigh,
+				() -> null, false, null, null, false, 0L, null, null, false, maxEmbedDepth, maxEmbedSizeBytes);
 	}
 
 	EmbedSpawner(final TikaDocument root, final ParseContext context, final Path outputPath,
@@ -134,7 +154,7 @@ public class EmbedSpawner extends EmbedParser {
 		// (including tests) that pass a pre-built ExecutorService continue to work unchanged.
 		this(root, context, outputPath, handlerFunction, embedMemoryBudgetBytes, tmp, memoryPressureHigh,
 				() -> ocrExecutor, ocrExecutor != null, progress, digester, ocrFanout, ocrMinImageBytes,
-				ocrParserClassName, null, false, DEFAULT_MAX_EMBED_DEPTH);
+				ocrParserClassName, null, false, DEFAULT_MAX_EMBED_DEPTH, DEFAULT_MAX_EMBED_SIZE_BYTES);
 	}
 
 	EmbedSpawner(final TikaDocument root, final ParseContext context, final Path outputPath,
@@ -149,7 +169,8 @@ public class EmbedSpawner extends EmbedParser {
 				 final String ocrParserClassName,
 				 final SpewSink sink,
 				 final boolean legacyUntitledNaming,
-				 final int maxEmbedDepth) {
+				 final int maxEmbedDepth,
+				 final long maxEmbedSizeBytes) {
 		super(root, context);
 		this.outputPath = outputPath;
 		this.handlerFunction = handlerFunction;
@@ -166,6 +187,7 @@ public class EmbedSpawner extends EmbedParser {
 		this.sink = sink;
 		this.legacyUntitledNaming = legacyUntitledNaming;
 		this.maxEmbedDepth = maxEmbedDepth;
+		this.maxEmbedSizeBytes = maxEmbedSizeBytes;
 		this.baseDepthOffset = 0;
 		this.reserved = new AtomicLong();
 		tikaDocumentStack.add(root);
@@ -192,6 +214,7 @@ public class EmbedSpawner extends EmbedParser {
 		this.sink = template.sink;
 		this.legacyUntitledNaming = template.legacyUntitledNaming;
 		this.maxEmbedDepth = template.maxEmbedDepth; // forks enforce the same depth on their own stack
+		this.maxEmbedSizeBytes = template.maxEmbedSizeBytes; // and the same per-embed size cap
 		// The fork re-adds `root` as size 1, discarding the depth the template's stack was actually
 		// at; capture that depth here so the guard measures ABSOLUTE nesting rather than
 		// depth-relative-to-the-fork. General form composes correctly if a fork is ever itself forked.
@@ -212,6 +235,8 @@ public class EmbedSpawner extends EmbedParser {
 	int stackDepth() { return tikaDocumentStack.size(); }
 	// Test accessor (package-private): the configured maximum embed nesting depth.
 	int maxEmbedDepthForTest() { return maxEmbedDepth; }
+	// Test accessor (package-private): the configured per-embed decompressed-size cap in bytes.
+	long maxEmbedSizeBytesForTest() { return maxEmbedSizeBytes; }
 	// Test accessor (package-private): the fork's inherited absolute-depth offset.
 	int baseDepthOffsetForTest() { return baseDepthOffset; }
 	// Test accessor (package-private): push a document onto this spawner's DFS stack.
@@ -273,6 +298,36 @@ public class EmbedSpawner extends EmbedParser {
 		}
 	}
 
+	// Record a size-refused embed on its parent: bump the parent's aggregate skip counter (indexed marker)
+	// and the per-file progress counter. Mirrors recordSkippedAtDepth exactly (same single-threaded-per-
+	// parent guarantee, same log-once-per-parent breadcrumb), but for the decompressed-size cap.
+	private void recordSkippedAtSize(final Metadata skipped) {
+		final Metadata parent = tikaDocumentStack.getLast().getMetadata();
+		int count = 0;
+		final String existing = parent.get(EMBEDS_SKIPPED_MAX_SIZE);
+		if (existing != null) {
+			try {
+				count = Integer.parseInt(existing);
+			} catch (final NumberFormatException ignored) {
+				// Treat an unparseable marker as zero and overwrite it.
+			}
+		}
+		parent.set(EMBEDS_SKIPPED_MAX_SIZE, Integer.toString(count + 1));
+		if (progress != null) {
+			progress.incrementEmbedsSkippedMaxSize();
+		}
+		// Log once per parent (on its first refused child): a bomb can hold many oversized siblings, and
+		// one WARN each would flood the log on the exact attack path. The per-parent marker and progress
+		// counter carry the full count; this WARN is a breadcrumb. Identify the parent by resource name
+		// (not getId()) for the same reason as recordSkippedAtDepth: getId() can force digest generation
+		// on a document whose content hash isn't computed yet, which would throw instead of merely logging.
+		if (existing == null) {
+			logger.warn("Skipping embed(s) exceeding max decompressed size {} bytes under \"{}\"; first: \"{}\" ({} bytes) (in \"{}\").",
+					maxEmbedSizeBytes, parent.get(TikaCoreProperties.RESOURCE_NAME_KEY),
+					skipped.get(TikaCoreProperties.RESOURCE_NAME_KEY), skipped.get(Metadata.CONTENT_LENGTH), root);
+		}
+	}
+
 	@Override
 	public void parseEmbedded(final InputStream input, final ContentHandler handler, final Metadata metadata,
 	                          final boolean outputHtml) throws SAXException, IOException {
@@ -303,6 +358,15 @@ public class EmbedSpawner extends EmbedParser {
 			// recorded on the parent and counted, so it is visible/alertable rather than silently lost.
 			if (exceedsMaxEmbedDepth(baseDepthOffset + tikaDocumentStack.size(), maxEmbedDepth)) {
 				recordSkippedAtDepth(metadata);
+				return;
+			}
+			// Decompression-bomb guard, part two: refuse an embed whose DECLARED decompressed size exceeds
+			// the cap BEFORE any spool or recursion, so a nested zip with multi-GiB entries can't fill /tmp
+			// or drive OOM even within the depth limit. Only fires when the size is actually known (see
+			// exceedsMaxEmbedSize); an unknown size is left unguarded rather than guessed, so streaming
+			// containers that don't report a length are never broken.
+			if (exceedsMaxEmbedSize(metadata, maxEmbedSizeBytes)) {
+				recordSkippedAtSize(metadata);
 				return;
 			}
 			if (progress != null) {
@@ -750,6 +814,26 @@ public class EmbedSpawner extends EmbedParser {
 	// "stackSize > maxEmbedDepth" allows depths 1..maxEmbedDepth and refuses maxEmbedDepth+1 down.
 	static boolean exceedsMaxEmbedDepth(final int stackSize, final int maxEmbedDepth) {
 		return maxEmbedDepth > 0 && stackSize > maxEmbedDepth;
+	}
+
+	// True when an embed must be refused for exceeding the per-embed decompressed-size cap.
+	// maxEmbedSizeBytes <= 0 disables the guard. The size is read from Tika's Metadata.CONTENT_LENGTH,
+	// which the container parser sets to the entry's UNCOMPRESSED size for archive embeds. When the length
+	// is absent or unparseable the size is unknown: we do NOT guess and leave the embed unguarded (returning
+	// false), so streaming containers that don't report a length keep working exactly as before.
+	static boolean exceedsMaxEmbedSize(final Metadata metadata, final long maxEmbedSizeBytes) {
+		if (maxEmbedSizeBytes <= 0) {
+			return false;
+		}
+		final String length = metadata.get(Metadata.CONTENT_LENGTH);
+		if (length == null) {
+			return false;
+		}
+		try {
+			return Long.parseLong(length.trim()) > maxEmbedSizeBytes;
+		} catch (final NumberFormatException ignored) {
+			return false;
+		}
 	}
 
 	private void saveEntries(final DirectoryEntry source, final DirectoryEntry destination) throws IOException {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -53,11 +53,13 @@ public class EmbedSpawner extends EmbedParser {
 	static final int DEFAULT_MAX_EMBED_DEPTH = 20;
 	// Metadata key set on a parent document, counting its direct children refused for exceeding the depth limit.
 	static final String EMBEDS_SKIPPED_MAX_DEPTH = "X-EXTRACT:embedsSkippedMaxDepth";
-	// Default per-embed decompressed-size cap (2 GiB): an embed whose declared decompressed size exceeds
-	// this is refused before it is spooled/recursed into (see exceedsMaxEmbedSize). Generous enough to
-	// pass any realistic single attachment while defusing the nested-zip "bomb" whose entries decompress
-	// to multi-GiB. Only enforced when the embed's size is actually known, so streaming is never broken.
-	static final long DEFAULT_MAX_EMBED_SIZE_BYTES = 2L * 1024 * 1024 * 1024;
+	// Default per-embed decompressed-size cap: DISABLED (0), i.e. legacy behavior where no embed is ever
+	// refused for its declared size. The guard is opt-in: an operator enables it by passing a positive
+	// maxEmbedSizeBytes (via datashare's --maxEmbedSizeBytes), after which an embed whose declared
+	// decompressed size exceeds the cap is refused before it is spooled/recursed into (see
+	// exceedsMaxEmbedSize). Kept off by default so a legitimate multi-GiB attachment (disk image, DB dump,
+	// video) is never silently dropped; operators facing nested-zip "bombs" opt in explicitly.
+	static final long DEFAULT_MAX_EMBED_SIZE_BYTES = 0L;
 	// Metadata key set on a parent document, counting its direct children refused for exceeding the size cap.
 	static final String EMBEDS_SKIPPED_MAX_SIZE = "X-EXTRACT:embedsSkippedMaxSize";
 

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -269,14 +270,20 @@ public class EmbedSpawner extends EmbedParser {
 		return untitledName(parentId, ordinal);
 	}
 
-	// Record a refused embed on its parent: bump the parent's aggregate skip counter (indexed marker)
-	// and the per-file progress counter. Runs on the walk thread for this parent's subtree, so the
-	// read-increment-set is single-threaded with respect to this parent (consistent with how other
-	// embed metadata is set during the walk).
-	private void recordSkippedAtDepth(final Metadata skipped) {
+	// Record a refused embed on its parent: bump the parent's aggregate skip counter under metadataKey
+	// (indexed marker) and the per-file progress counter, then emit a once-per-parent WARN breadcrumb.
+	// Runs on the walk thread for this parent's subtree, so the read-increment-set is single-threaded
+	// with respect to this parent (consistent with how other embed metadata is set during the walk).
+	// Both skip guards (depth and size) route through here so their skip accounting can never diverge;
+	// only the marker key, the progress incrementer, and the breadcrumb wording differ. The breadcrumb
+	// is logged once per parent (on its first refused child): a wide bomb can have very many siblings
+	// past the boundary, and one WARN each would flood the log on the exact attack path. The per-parent
+	// marker and the progress counter carry the full count; this WARN is only a breadcrumb.
+	private void recordSkip(final String metadataKey, final Runnable progressIncrement,
+	                        final Consumer<Metadata> logFirstBreadcrumb) {
 		final Metadata parent = tikaDocumentStack.getLast().getMetadata();
 		int count = 0;
-		final String existing = parent.get(EMBEDS_SKIPPED_MAX_DEPTH);
+		final String existing = parent.get(metadataKey);
 		if (existing != null) {
 			try {
 				count = Integer.parseInt(existing);
@@ -284,51 +291,32 @@ public class EmbedSpawner extends EmbedParser {
 				// Treat an unparseable marker as zero and overwrite it.
 			}
 		}
-		parent.set(EMBEDS_SKIPPED_MAX_DEPTH, Integer.toString(count + 1));
+		parent.set(metadataKey, Integer.toString(count + 1));
 		if (progress != null) {
-			progress.incrementEmbedsSkippedMaxDepth();
+			progressIncrement.run();
 		}
-		// Log once per parent (on its first refused child): a wide bomb can have very many siblings
-		// past the boundary, and one WARN each would flood the log on the exact attack path. The
-		// per-parent marker and the progress counter carry the full count; this WARN is a breadcrumb.
-		// Identify the parent by its resource name rather than getId(): the latter can force digest
-		// generation on documents whose content hash hasn't been computed yet (e.g. a PST folder
-		// document mid-walk), which would throw instead of merely logging.
 		if (existing == null) {
-			logger.warn("Skipping embed(s) nested beyond max depth {} under \"{}\"; first: \"{}\" (in \"{}\").",
-					maxEmbedDepth, parent.get(TikaCoreProperties.RESOURCE_NAME_KEY),
-					skipped.get(TikaCoreProperties.RESOURCE_NAME_KEY), root);
+			logFirstBreadcrumb.accept(parent);
 		}
 	}
 
-	// Record a size-refused embed on its parent: bump the parent's aggregate skip counter (indexed marker)
-	// and the per-file progress counter. Mirrors recordSkippedAtDepth exactly (same single-threaded-per-
-	// parent guarantee, same log-once-per-parent breadcrumb), but for the decompressed-size cap.
+	// Identify the parent by its resource name rather than getId() in the breadcrumbs below: the latter can
+	// force digest generation on documents whose content hash hasn't been computed yet (e.g. a PST folder
+	// document mid-walk), which would throw instead of merely logging.
+	private void recordSkippedAtDepth(final Metadata skipped) {
+		recordSkip(EMBEDS_SKIPPED_MAX_DEPTH,
+				() -> progress.incrementEmbedsSkippedMaxDepth(),
+				parent -> logger.warn("Skipping embed(s) nested beyond max depth {} under \"{}\"; first: \"{}\" (in \"{}\").",
+						maxEmbedDepth, parent.get(TikaCoreProperties.RESOURCE_NAME_KEY),
+						skipped.get(TikaCoreProperties.RESOURCE_NAME_KEY), root));
+	}
+
 	private void recordSkippedAtSize(final Metadata skipped) {
-		final Metadata parent = tikaDocumentStack.getLast().getMetadata();
-		int count = 0;
-		final String existing = parent.get(EMBEDS_SKIPPED_MAX_SIZE);
-		if (existing != null) {
-			try {
-				count = Integer.parseInt(existing);
-			} catch (final NumberFormatException ignored) {
-				// Treat an unparseable marker as zero and overwrite it.
-			}
-		}
-		parent.set(EMBEDS_SKIPPED_MAX_SIZE, Integer.toString(count + 1));
-		if (progress != null) {
-			progress.incrementEmbedsSkippedMaxSize();
-		}
-		// Log once per parent (on its first refused child): a bomb can hold many oversized siblings, and
-		// one WARN each would flood the log on the exact attack path. The per-parent marker and progress
-		// counter carry the full count; this WARN is a breadcrumb. Identify the parent by resource name
-		// (not getId()) for the same reason as recordSkippedAtDepth: getId() can force digest generation
-		// on a document whose content hash isn't computed yet, which would throw instead of merely logging.
-		if (existing == null) {
-			logger.warn("Skipping embed(s) exceeding max decompressed size {} bytes under \"{}\"; first: \"{}\" ({} bytes) (in \"{}\").",
-					maxEmbedSizeBytes, parent.get(TikaCoreProperties.RESOURCE_NAME_KEY),
-					skipped.get(TikaCoreProperties.RESOURCE_NAME_KEY), skipped.get(Metadata.CONTENT_LENGTH), root);
-		}
+		recordSkip(EMBEDS_SKIPPED_MAX_SIZE,
+				() -> progress.incrementEmbedsSkippedMaxSize(),
+				parent -> logger.warn("Skipping embed(s) exceeding max decompressed size {} bytes under \"{}\"; first: \"{}\" ({} bytes) (in \"{}\").",
+						maxEmbedSizeBytes, parent.get(TikaCoreProperties.RESOURCE_NAME_KEY),
+						skipped.get(TikaCoreProperties.RESOURCE_NAME_KEY), skipped.get(Metadata.CONTENT_LENGTH), root));
 	}
 
 	@Override

--- a/extract-lib/src/main/java/org/icij/extract/extractor/ExtractionProgress.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/ExtractionProgress.java
@@ -11,6 +11,7 @@ public class ExtractionProgress {
     private final AtomicLong ocrSubmitted = new AtomicLong();
     private final AtomicLong ocrCompleted = new AtomicLong();
     private final AtomicLong embedsSkippedMaxDepth = new AtomicLong();
+    private final AtomicLong embedsSkippedMaxSize = new AtomicLong();
 
     public ExtractionProgress(final Path path, final long startMillis) {
         this.path = path;
@@ -23,9 +24,11 @@ public class ExtractionProgress {
     public long ocrSubmitted() { return ocrSubmitted.get(); }
     public long ocrCompleted() { return ocrCompleted.get(); }
     public long embedsSkippedMaxDepth() { return embedsSkippedMaxDepth.get(); }
+    public long embedsSkippedMaxSize() { return embedsSkippedMaxSize.get(); }
     public void incrementEmbeds() { embeds.incrementAndGet(); }
     public void incrementOcrSubmitted() { ocrSubmitted.incrementAndGet(); }
     public void incrementOcrCompleted() { ocrCompleted.incrementAndGet(); }
     public void incrementEmbedsSkippedMaxDepth() { embedsSkippedMaxDepth.incrementAndGet(); }
+    public void incrementEmbedsSkippedMaxSize() { embedsSkippedMaxSize.incrementAndGet(); }
     public long elapsedMillis(final long now) { return now - startMillis; }
 }

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -150,6 +150,10 @@ import static org.icij.extract.extractor.ArtifactUtils.getEmbeddedPath;
 @Option(name = "maxEmbedDepth", description = "Maximum nesting depth of embedded documents to " +
         "descend into. Embeds deeper than this are skipped (recorded, not parsed) to guard against " +
         "decompression-bomb archives. Defaults to 20. Set to 0 to disable.", parameter = "count")
+@Option(name = "maxEmbedSizeBytes", description = "Maximum declared decompressed size, in bytes, of a " +
+        "single embedded document to descend into. Embeds larger than this are skipped (recorded, not " +
+        "parsed) to guard against decompression-bomb archives whose entries expand to multi-GiB. Only " +
+        "enforced when the embed's size is known. Defaults to 2 GiB. Set to 0 to disable.", parameter = "bytes")
 public class Extractor implements AutoCloseable {
 
     public static final String PAGES_JSON = "pages.json";
@@ -214,6 +218,7 @@ public class Extractor implements AutoCloseable {
     private int pstParseParallelism = Runtime.getRuntime().availableProcessors();
     private boolean legacyUntitledNaming = false;
     private int maxEmbedDepth = EmbedSpawner.DEFAULT_MAX_EMBED_DEPTH;
+    private long maxEmbedSizeBytes = EmbedSpawner.DEFAULT_MAX_EMBED_SIZE_BYTES;
     // Null until first use; created lazily by parseExecutor(), mirroring the OCR pool.
     private volatile ExecutorService pstParseExecutor = null;
     private ExtractionProgressTracker progressTracker;
@@ -317,6 +322,12 @@ public class Extractor implements AutoCloseable {
                     }
                     this.maxEmbedDepth = Math.max(0, n);
                 });
+        options.valueIfPresent("maxEmbedSizeBytes").map(Long::parseLong).ifPresent(n -> {
+            if (n < 0) {
+                logger.warn("maxEmbedSizeBytes {} is negative; clamping to 0 (size guard disabled).", n);
+            }
+            this.maxEmbedSizeBytes = Math.max(0L, n);
+        });
         // Legacy naming and PST folder fan-out are mutually exclusive. The legacy global untitled_N
         // counter is serial-only: each fan-out fork carries its own counter starting at 0, so with
         // fan-out on the nameless embeds would get nondeterministic, non-matching names, defeating the
@@ -404,6 +415,7 @@ public class Extractor implements AutoCloseable {
     public int getPstParseParallelism() { return pstParseParallelism; }
     public boolean isLegacyUntitledNaming() { return legacyUntitledNaming; }
     public int getMaxEmbedDepth() { return maxEmbedDepth; }
+    public long getMaxEmbedSizeBytes() { return maxEmbedSizeBytes; }
 
     ExecutorService pstParseExecutorOrNull() { return pstParseExecutor; }
 
@@ -964,7 +976,7 @@ public class Extractor implements AutoCloseable {
                             embedTextResources, new MemoryPressureGauge(embedMemoryPressureThreshold),
                             this::ocrExecutor, !ocrDisabled, currentProgress, digester,
                             ocrFanout, ocrMinImageBytes, ocrParserClassName, sink, legacyUntitledNaming,
-                            maxEmbedDepth));
+                            maxEmbedDepth, maxEmbedSizeBytes));
             context.set(org.icij.extract.parser.PstFanoutConfig.class,
                     new org.icij.extract.parser.PstFanoutConfig(pstFolderFanout, this::pstParseExecutor));
         } else if (EmbedHandling.CONCATENATE == embedHandling) {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -153,7 +153,8 @@ import static org.icij.extract.extractor.ArtifactUtils.getEmbeddedPath;
 @Option(name = "maxEmbedSizeBytes", description = "Maximum declared decompressed size, in bytes, of a " +
         "single embedded document to descend into. Embeds larger than this are skipped (recorded, not " +
         "parsed) to guard against decompression-bomb archives whose entries expand to multi-GiB. Only " +
-        "enforced when the embed's size is known. Defaults to 2 GiB. Set to 0 to disable.", parameter = "bytes")
+        "enforced when the embed's size is known. Disabled by default (0). Set to a positive byte " +
+        "count to enable.", parameter = "bytes")
 public class Extractor implements AutoCloseable {
 
     public static final String PAGES_JSON = "pages.json";

--- a/extract-lib/src/main/java/org/icij/extract/extractor/LoggingProgressListener.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/LoggingProgressListener.java
@@ -16,9 +16,9 @@ public class LoggingProgressListener implements ProgressListener {
 
     static String formatLine(final ExtractionProgress p, final long now) {
         final long seconds = p.elapsedMillis(now) / 1000L;
-        return String.format("%s: %ds, %d embeds, %d/%d OCR done, %d skipped(maxDepth)",
+        return String.format("%s: %ds, %d embeds, %d/%d OCR done, %d skipped(maxDepth), %d skipped(maxSize)",
                 p.path(), seconds, p.embedsParsed(), p.ocrCompleted(), p.ocrSubmitted(),
-                p.embedsSkippedMaxDepth());
+                p.embedsSkippedMaxDepth(), p.embedsSkippedMaxSize());
     }
 
     @Override

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
@@ -47,10 +47,16 @@ public class EmbedSpawnerSizeGuardTest {
     }
 
     private Metadata nonInline(final String name, final Long contentLength) {
+        return nonInlineRaw(name, contentLength == null ? null : Long.toString(contentLength));
+    }
+
+    // Same as nonInline but sets CONTENT_LENGTH to a raw string, so tests can exercise values that are not
+    // representable as a Java long (e.g. a crafted ZIP64 size above Long.MAX_VALUE) or non-numeric garbage.
+    private Metadata nonInlineRaw(final String name, final String rawContentLength) {
         final Metadata m = new Metadata();
         m.set(org.apache.tika.metadata.TikaCoreProperties.RESOURCE_NAME_KEY, name);
-        if (contentLength != null) {
-            m.set(Metadata.CONTENT_LENGTH, Long.toString(contentLength));
+        if (rawContentLength != null) {
+            m.set(Metadata.CONTENT_LENGTH, rawContentLength);
         }
         return m;
     }
@@ -112,6 +118,39 @@ public class EmbedSpawnerSizeGuardTest {
         // No CONTENT_LENGTH on the embed: size is unknown, so the guard does not fire (do not guess).
         spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
                 new BodyContentHandler(), nonInline("unknown.bin", null), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
+        assertThat(parent.getEmbeds()).isNotEmpty();
+    }
+
+    @Test
+    public void testDeclaredSizeAboveLongRangeIsRefused() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // A crafted ZIP64 entry can declare an uncompressed size above Long.MAX_VALUE. Such a value is not
+        // "unknown" — it is unambiguously enormous — so it must be refused, not fail open past Long.parseLong.
+        final String aboveLongMax = "18446744073709551615"; // 2^64 - 1, > Long.MAX_VALUE
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInlineRaw("zip64-bomb.bin", aboveLongMax), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isEqualTo("1");
+        assertThat(parent.getEmbeds()).isEmpty();
+    }
+
+    @Test
+    public void testNonNumericSizeIsNotGuarded() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // A genuinely non-numeric CONTENT_LENGTH is unknown (not a huge number), so the guard does not fire:
+        // we do not guess, matching the absent-length behaviour.
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInlineRaw("weird.bin", "not-a-number"), false);
 
         assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
         assertThat(parent.getEmbeds()).isNotEmpty();

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
@@ -1,0 +1,126 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.io.TemporaryResources;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.BodyContentHandler;
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.TikaDocument;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class EmbedSpawnerSizeGuardTest {
+
+    private TikaDocument root(final String path) {
+        return new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", Charset.defaultCharset()))
+                .create(Paths.get(path));
+    }
+
+    // Serial spawner with the depth guard disabled and an explicit, small decompressed-size cap and no
+    // output path (no spooling), so only the size guard is under test.
+    private EmbedSpawner spawnerWithSize(final TikaDocument root, final long maxEmbedSizeBytes) {
+        return new EmbedSpawner(root, new ParseContext(), null,
+                w -> new BodyContentHandler(w),
+                64L * 1024 * 1024, new TemporaryResources(), () -> false, 0, maxEmbedSizeBytes);
+    }
+
+    private TikaDocument parent() {
+        return new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", StandardCharsets.UTF_8))
+                .create(Paths.get("/tmp/parent"));
+    }
+
+    private Metadata nonInline(final String name, final Long contentLength) {
+        final Metadata m = new Metadata();
+        m.set(org.apache.tika.metadata.TikaCoreProperties.RESOURCE_NAME_KEY, name);
+        if (contentLength != null) {
+            m.set(Metadata.CONTENT_LENGTH, Long.toString(contentLength));
+        }
+        return m;
+    }
+
+    @Test
+    public void testEmbedBeyondSizeIsRefusedAndRecorded() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // Declared decompressed size (1000) exceeds the 100-byte cap: the embed is refused.
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("bomb.bin", 1000L), false);
+
+        // Refused: no embed added to the parent, and the skip is recorded on the parent.
+        assertThat(parent.getEmbeds()).isEmpty();
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isEqualTo("1");
+    }
+
+    @Test
+    public void testSecondRefusedEmbedIncrementsParentMarker() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        spawner.parseEmbedded(new ByteArrayInputStream("a".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("bomb1.bin", 1000L), false);
+        spawner.parseEmbedded(new ByteArrayInputStream("b".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("bomb2.bin", 2000L), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isEqualTo("2");
+        assertThat(parent.getEmbeds()).isEmpty();
+    }
+
+    @Test
+    public void testUnderCapEmbedStillExtracts() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // Declared decompressed size (50) is under the 100-byte cap: the embed takes the normal spawn path.
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("real.bin", 50L), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
+        assertThat(parent.getEmbeds()).isNotEmpty();
+    }
+
+    @Test
+    public void testUnknownSizeIsNotGuarded() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // No CONTENT_LENGTH on the embed: size is unknown, so the guard does not fire (do not guess).
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("unknown.bin", null), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
+        assertThat(parent.getEmbeds()).isNotEmpty();
+    }
+
+    @Test
+    public void testGuardDisabledWhenSizeIsZero() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 0L); // disabled
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // Even a huge declared size is not refused when the cap is disabled (cap <= 0).
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("huge.bin", 10L * 1024 * 1024 * 1024), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
+        assertThat(parent.getEmbeds()).isNotEmpty();
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
@@ -32,6 +32,14 @@ public class EmbedSpawnerSizeGuardTest {
                 64L * 1024 * 1024, new TemporaryResources(), () -> false, 0, maxEmbedSizeBytes);
     }
 
+    // Serial spawner with the depth guard disabled and NO explicit size cap, so it carries the shipped
+    // default (DEFAULT_MAX_EMBED_SIZE_BYTES). Used to assert the guard is off unless opted into.
+    private EmbedSpawner spawnerWithDefaultSize(final TikaDocument root) {
+        return new EmbedSpawner(root, new ParseContext(), null,
+                w -> new BodyContentHandler(w),
+                64L * 1024 * 1024, new TemporaryResources(), () -> false, 0);
+    }
+
     private TikaDocument parent() {
         return new DocumentFactory()
                 .withIdentifier(new DigestIdentifier("SHA-256", StandardCharsets.UTF_8))
@@ -117,6 +125,24 @@ public class EmbedSpawnerSizeGuardTest {
         spawner.pushForTest(parent);
 
         // Even a huge declared size is not refused when the cap is disabled (cap <= 0).
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("huge.bin", 10L * 1024 * 1024 * 1024), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
+        assertThat(parent.getEmbeds()).isNotEmpty();
+    }
+
+    @Test
+    public void testGuardDisabledByDefault() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        // No explicit cap: the spawner carries the shipped default, which is disabled (opt-in guard).
+        final EmbedSpawner spawner = spawnerWithDefaultSize(root);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // The default must be disabled, so even a huge declared size is extracted, not skipped: a
+        // legitimate multi-GiB attachment is never silently dropped unless an operator opts in.
+        assertThat(spawner.maxEmbedSizeBytesForTest()).isEqualTo(0L);
         spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
                 new BodyContentHandler(), nonInline("huge.bin", 10L * 1024 * 1024 * 1024), false);
 

--- a/extract-lib/src/test/java/org/icij/extract/extractor/LoggingProgressListenerTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/LoggingProgressListenerTest.java
@@ -17,7 +17,7 @@ public class LoggingProgressListenerTest {
         p.incrementOcrSubmitted(); p.incrementOcrSubmitted(); p.incrementOcrSubmitted();
         p.incrementOcrCompleted();
         assertThat(LoggingProgressListener.formatLine(p, 3_000L))
-            .isEqualTo("/x.ost: 3s, 2 embeds, 1/3 OCR done, 0 skipped(maxDepth)");
+            .isEqualTo("/x.ost: 3s, 2 embeds, 1/3 OCR done, 0 skipped(maxDepth), 0 skipped(maxSize)");
     }
 
     @Test public void testFormatLineIncludesSkippedCount() {
@@ -25,6 +25,13 @@ public class LoggingProgressListenerTest {
         p.incrementEmbeds();
         p.incrementEmbedsSkippedMaxDepth();
         assertThat(LoggingProgressListener.formatLine(p, 3_000L)).contains("1 skipped(maxDepth)");
+    }
+
+    @Test public void testFormatLineIncludesSkippedMaxSizeCount() {
+        ExtractionProgress p = new ExtractionProgress(Paths.get("/x.ost"), 1_000L);
+        p.incrementEmbeds();
+        p.incrementEmbedsSkippedMaxSize();
+        assertThat(LoggingProgressListener.formatLine(p, 3_000L)).contains("1 skipped(maxSize)");
     }
 
     @Test public void testEmptyInFlightLogsNothing() {


### PR DESCRIPTION
Adds an optional cap on the decompressed size of embedded archive entries, so a single crafted or accidental multi-GB nested archive can no longer fill the disk and crash extraction. Disabled by default; opt in per deployment.