### PR TITLE
chore(document): quiet the no-content-hash embed warning

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/document/DigestIdentifier.java
+++ b/extract-lib/src/main/java/org/icij/extract/document/DigestIdentifier.java
@@ -45,7 +45,7 @@ public class DigestIdentifier extends AbstractIdentifier {
 		if (null != hash) {
 			digest.update(hash.getBytes(charset));
 		} else {
-			LoggerFactory.getLogger(getClass()).warn(
+			LoggerFactory.getLogger(getClass()).debug(
 					"No content hash for embed \"{}\" (relId {}) under parent {}; deriving id without the file digest.",
 					name, embeddedRelationshipId, embed.getParent().getId());
 		}


### PR DESCRIPTION
Silences a benign per-embed warning that flooded the logs (thousands of lines in one production run) and buried real errors. No behavior change.