### PR TITLE
feat(extractor): resumable seam for giant OST/PST parsing

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -53,6 +53,13 @@ public class EmbedSpawner extends EmbedParser {
 	static final int DEFAULT_MAX_EMBED_DEPTH = 20;
 	// Metadata key set on a parent document, counting its direct children refused for exceeding the depth limit.
 	static final String EMBEDS_SKIPPED_MAX_DEPTH = "X-EXTRACT:embedsSkippedMaxDepth";
+	// Default per-embed decompressed-size cap (2 GiB): an embed whose declared decompressed size exceeds
+	// this is refused before it is spooled/recursed into (see exceedsMaxEmbedSize). Generous enough to
+	// pass any realistic single attachment while defusing the nested-zip "bomb" whose entries decompress
+	// to multi-GiB. Only enforced when the embed's size is actually known, so streaming is never broken.
+	static final long DEFAULT_MAX_EMBED_SIZE_BYTES = 2L * 1024 * 1024 * 1024;
+	// Metadata key set on a parent document, counting its direct children refused for exceeding the size cap.
+	static final String EMBEDS_SKIPPED_MAX_SIZE = "X-EXTRACT:embedsSkippedMaxSize";
 
 	private final Path outputPath;
 	private final Function<Writer, ContentHandler> handlerFunction;
@@ -69,6 +76,9 @@ public class EmbedSpawner extends EmbedParser {
 	// Pre-branch global counter, used only when legacyUntitledNaming is true.
 	private int untitledGlobalCounter = 0;
 	private final int maxEmbedDepth;
+	// Per-embed decompressed-size cap in bytes; an embed whose declared size exceeds this is refused
+	// (see exceedsMaxEmbedSize). <= 0 disables the guard.
+	private final long maxEmbedSizeBytes;
 	// Absolute nesting depth of this spawner's reseeded root within the outer document tree.
 	// 0 for the top-level spawner; a PST fan-out fork inherits the depth its shared root sat at,
 	// so the depth guard measures ABSOLUTE nesting rather than depth-relative-to-the-fork.
@@ -118,7 +128,17 @@ public class EmbedSpawner extends EmbedParser {
 				 final long embedMemoryBudgetBytes, final TemporaryResources tmp,
 				 final BooleanSupplier memoryPressureHigh, final int maxEmbedDepth) {
 		this(root, context, outputPath, handlerFunction, embedMemoryBudgetBytes, tmp, memoryPressureHigh,
-				() -> null, false, null, null, false, 0L, null, null, false, maxEmbedDepth);
+				maxEmbedDepth, DEFAULT_MAX_EMBED_SIZE_BYTES);
+	}
+
+	// Serial mode with explicit depth AND decompressed-size limits (test-friendly). No fan-out, no OCR.
+	EmbedSpawner(final TikaDocument root, final ParseContext context, final Path outputPath,
+				 final Function<Writer, ContentHandler> handlerFunction,
+				 final long embedMemoryBudgetBytes, final TemporaryResources tmp,
+				 final BooleanSupplier memoryPressureHigh, final int maxEmbedDepth,
+				 final long maxEmbedSizeBytes) {
+		this(root, context, outputPath, handlerFunction, embedMemoryBudgetBytes, tmp, memoryPressureHigh,
+				() -> null, false, null, null, false, 0L, null, null, false, maxEmbedDepth, maxEmbedSizeBytes);
 	}
 
 	EmbedSpawner(final TikaDocument root, final ParseContext context, final Path outputPath,
@@ -134,7 +154,7 @@ public class EmbedSpawner extends EmbedParser {
 		// (including tests) that pass a pre-built ExecutorService continue to work unchanged.
 		this(root, context, outputPath, handlerFunction, embedMemoryBudgetBytes, tmp, memoryPressureHigh,
 				() -> ocrExecutor, ocrExecutor != null, progress, digester, ocrFanout, ocrMinImageBytes,
-				ocrParserClassName, null, false, DEFAULT_MAX_EMBED_DEPTH);
+				ocrParserClassName, null, false, DEFAULT_MAX_EMBED_DEPTH, DEFAULT_MAX_EMBED_SIZE_BYTES);
 	}
 
 	EmbedSpawner(final TikaDocument root, final ParseContext context, final Path outputPath,
@@ -149,7 +169,8 @@ public class EmbedSpawner extends EmbedParser {
 				 final String ocrParserClassName,
 				 final SpewSink sink,
 				 final boolean legacyUntitledNaming,
-				 final int maxEmbedDepth) {
+				 final int maxEmbedDepth,
+				 final long maxEmbedSizeBytes) {
 		super(root, context);
 		this.outputPath = outputPath;
 		this.handlerFunction = handlerFunction;
@@ -166,6 +187,7 @@ public class EmbedSpawner extends EmbedParser {
 		this.sink = sink;
 		this.legacyUntitledNaming = legacyUntitledNaming;
 		this.maxEmbedDepth = maxEmbedDepth;
+		this.maxEmbedSizeBytes = maxEmbedSizeBytes;
 		this.baseDepthOffset = 0;
 		this.reserved = new AtomicLong();
 		tikaDocumentStack.add(root);
@@ -192,6 +214,7 @@ public class EmbedSpawner extends EmbedParser {
 		this.sink = template.sink;
 		this.legacyUntitledNaming = template.legacyUntitledNaming;
 		this.maxEmbedDepth = template.maxEmbedDepth; // forks enforce the same depth on their own stack
+		this.maxEmbedSizeBytes = template.maxEmbedSizeBytes; // and the same per-embed size cap
 		// The fork re-adds `root` as size 1, discarding the depth the template's stack was actually
 		// at; capture that depth here so the guard measures ABSOLUTE nesting rather than
 		// depth-relative-to-the-fork. General form composes correctly if a fork is ever itself forked.
@@ -212,6 +235,8 @@ public class EmbedSpawner extends EmbedParser {
 	int stackDepth() { return tikaDocumentStack.size(); }
 	// Test accessor (package-private): the configured maximum embed nesting depth.
 	int maxEmbedDepthForTest() { return maxEmbedDepth; }
+	// Test accessor (package-private): the configured per-embed decompressed-size cap in bytes.
+	long maxEmbedSizeBytesForTest() { return maxEmbedSizeBytes; }
 	// Test accessor (package-private): the fork's inherited absolute-depth offset.
 	int baseDepthOffsetForTest() { return baseDepthOffset; }
 	// Test accessor (package-private): push a document onto this spawner's DFS stack.
@@ -273,6 +298,36 @@ public class EmbedSpawner extends EmbedParser {
 		}
 	}
 
+	// Record a size-refused embed on its parent: bump the parent's aggregate skip counter (indexed marker)
+	// and the per-file progress counter. Mirrors recordSkippedAtDepth exactly (same single-threaded-per-
+	// parent guarantee, same log-once-per-parent breadcrumb), but for the decompressed-size cap.
+	private void recordSkippedAtSize(final Metadata skipped) {
+		final Metadata parent = tikaDocumentStack.getLast().getMetadata();
+		int count = 0;
+		final String existing = parent.get(EMBEDS_SKIPPED_MAX_SIZE);
+		if (existing != null) {
+			try {
+				count = Integer.parseInt(existing);
+			} catch (final NumberFormatException ignored) {
+				// Treat an unparseable marker as zero and overwrite it.
+			}
+		}
+		parent.set(EMBEDS_SKIPPED_MAX_SIZE, Integer.toString(count + 1));
+		if (progress != null) {
+			progress.incrementEmbedsSkippedMaxSize();
+		}
+		// Log once per parent (on its first refused child): a bomb can hold many oversized siblings, and
+		// one WARN each would flood the log on the exact attack path. The per-parent marker and progress
+		// counter carry the full count; this WARN is a breadcrumb. Identify the parent by resource name
+		// (not getId()) for the same reason as recordSkippedAtDepth: getId() can force digest generation
+		// on a document whose content hash isn't computed yet, which would throw instead of merely logging.
+		if (existing == null) {
+			logger.warn("Skipping embed(s) exceeding max decompressed size {} bytes under \"{}\"; first: \"{}\" ({} bytes) (in \"{}\").",
+					maxEmbedSizeBytes, parent.get(TikaCoreProperties.RESOURCE_NAME_KEY),
+					skipped.get(TikaCoreProperties.RESOURCE_NAME_KEY), skipped.get(Metadata.CONTENT_LENGTH), root);
+		}
+	}
+
 	@Override
 	public void parseEmbedded(final InputStream input, final ContentHandler handler, final Metadata metadata,
 	                          final boolean outputHtml) throws SAXException, IOException {
@@ -303,6 +358,15 @@ public class EmbedSpawner extends EmbedParser {
 			// recorded on the parent and counted, so it is visible/alertable rather than silently lost.
 			if (exceedsMaxEmbedDepth(baseDepthOffset + tikaDocumentStack.size(), maxEmbedDepth)) {
 				recordSkippedAtDepth(metadata);
+				return;
+			}
+			// Decompression-bomb guard, part two: refuse an embed whose DECLARED decompressed size exceeds
+			// the cap BEFORE any spool or recursion, so a nested zip with multi-GiB entries can't fill /tmp
+			// or drive OOM even within the depth limit. Only fires when the size is actually known (see
+			// exceedsMaxEmbedSize); an unknown size is left unguarded rather than guessed, so streaming
+			// containers that don't report a length are never broken.
+			if (exceedsMaxEmbedSize(metadata, maxEmbedSizeBytes)) {
+				recordSkippedAtSize(metadata);
 				return;
 			}
 			if (progress != null) {
@@ -750,6 +814,26 @@ public class EmbedSpawner extends EmbedParser {
 	// "stackSize > maxEmbedDepth" allows depths 1..maxEmbedDepth and refuses maxEmbedDepth+1 down.
 	static boolean exceedsMaxEmbedDepth(final int stackSize, final int maxEmbedDepth) {
 		return maxEmbedDepth > 0 && stackSize > maxEmbedDepth;
+	}
+
+	// True when an embed must be refused for exceeding the per-embed decompressed-size cap.
+	// maxEmbedSizeBytes <= 0 disables the guard. The size is read from Tika's Metadata.CONTENT_LENGTH,
+	// which the container parser sets to the entry's UNCOMPRESSED size for archive embeds. When the length
+	// is absent or unparseable the size is unknown: we do NOT guess and leave the embed unguarded (returning
+	// false), so streaming containers that don't report a length keep working exactly as before.
+	static boolean exceedsMaxEmbedSize(final Metadata metadata, final long maxEmbedSizeBytes) {
+		if (maxEmbedSizeBytes <= 0) {
+			return false;
+		}
+		final String length = metadata.get(Metadata.CONTENT_LENGTH);
+		if (length == null) {
+			return false;
+		}
+		try {
+			return Long.parseLong(length.trim()) > maxEmbedSizeBytes;
+		} catch (final NumberFormatException ignored) {
+			return false;
+		}
 	}
 
 	private void saveEntries(final DirectoryEntry source, final DirectoryEntry destination) throws IOException {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -53,11 +53,13 @@ public class EmbedSpawner extends EmbedParser {
 	static final int DEFAULT_MAX_EMBED_DEPTH = 20;
 	// Metadata key set on a parent document, counting its direct children refused for exceeding the depth limit.
 	static final String EMBEDS_SKIPPED_MAX_DEPTH = "X-EXTRACT:embedsSkippedMaxDepth";
-	// Default per-embed decompressed-size cap (2 GiB): an embed whose declared decompressed size exceeds
-	// this is refused before it is spooled/recursed into (see exceedsMaxEmbedSize). Generous enough to
-	// pass any realistic single attachment while defusing the nested-zip "bomb" whose entries decompress
-	// to multi-GiB. Only enforced when the embed's size is actually known, so streaming is never broken.
-	static final long DEFAULT_MAX_EMBED_SIZE_BYTES = 2L * 1024 * 1024 * 1024;
+	// Default per-embed decompressed-size cap: DISABLED (0), i.e. legacy behavior where no embed is ever
+	// refused for its declared size. The guard is opt-in: an operator enables it by passing a positive
+	// maxEmbedSizeBytes (via datashare's --maxEmbedSizeBytes), after which an embed whose declared
+	// decompressed size exceeds the cap is refused before it is spooled/recursed into (see
+	// exceedsMaxEmbedSize). Kept off by default so a legitimate multi-GiB attachment (disk image, DB dump,
+	// video) is never silently dropped; operators facing nested-zip "bombs" opt in explicitly.
+	static final long DEFAULT_MAX_EMBED_SIZE_BYTES = 0L;
 	// Metadata key set on a parent document, counting its direct children refused for exceeding the size cap.
 	static final String EMBEDS_SKIPPED_MAX_SIZE = "X-EXTRACT:embedsSkippedMaxSize";
 

--- a/extract-lib/src/main/java/org/icij/extract/extractor/ExtractionProgress.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/ExtractionProgress.java
@@ -11,6 +11,7 @@ public class ExtractionProgress {
     private final AtomicLong ocrSubmitted = new AtomicLong();
     private final AtomicLong ocrCompleted = new AtomicLong();
     private final AtomicLong embedsSkippedMaxDepth = new AtomicLong();
+    private final AtomicLong embedsSkippedMaxSize = new AtomicLong();
 
     public ExtractionProgress(final Path path, final long startMillis) {
         this.path = path;
@@ -23,9 +24,11 @@ public class ExtractionProgress {
     public long ocrSubmitted() { return ocrSubmitted.get(); }
     public long ocrCompleted() { return ocrCompleted.get(); }
     public long embedsSkippedMaxDepth() { return embedsSkippedMaxDepth.get(); }
+    public long embedsSkippedMaxSize() { return embedsSkippedMaxSize.get(); }
     public void incrementEmbeds() { embeds.incrementAndGet(); }
     public void incrementOcrSubmitted() { ocrSubmitted.incrementAndGet(); }
     public void incrementOcrCompleted() { ocrCompleted.incrementAndGet(); }
     public void incrementEmbedsSkippedMaxDepth() { embedsSkippedMaxDepth.incrementAndGet(); }
+    public void incrementEmbedsSkippedMaxSize() { embedsSkippedMaxSize.incrementAndGet(); }
     public long elapsedMillis(final long now) { return now - startMillis; }
 }

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -150,6 +150,10 @@ import static org.icij.extract.extractor.ArtifactUtils.getEmbeddedPath;
 @Option(name = "maxEmbedDepth", description = "Maximum nesting depth of embedded documents to " +
         "descend into. Embeds deeper than this are skipped (recorded, not parsed) to guard against " +
         "decompression-bomb archives. Defaults to 20. Set to 0 to disable.", parameter = "count")
+@Option(name = "maxEmbedSizeBytes", description = "Maximum declared decompressed size, in bytes, of a " +
+        "single embedded document to descend into. Embeds larger than this are skipped (recorded, not " +
+        "parsed) to guard against decompression-bomb archives whose entries expand to multi-GiB. Only " +
+        "enforced when the embed's size is known. Defaults to 2 GiB. Set to 0 to disable.", parameter = "bytes")
 public class Extractor implements AutoCloseable {
 
     public static final String PAGES_JSON = "pages.json";
@@ -214,6 +218,7 @@ public class Extractor implements AutoCloseable {
     private int pstParseParallelism = Runtime.getRuntime().availableProcessors();
     private boolean legacyUntitledNaming = false;
     private int maxEmbedDepth = EmbedSpawner.DEFAULT_MAX_EMBED_DEPTH;
+    private long maxEmbedSizeBytes = EmbedSpawner.DEFAULT_MAX_EMBED_SIZE_BYTES;
     // Null until first use; created lazily by parseExecutor(), mirroring the OCR pool.
     private volatile ExecutorService pstParseExecutor = null;
     private ExtractionProgressTracker progressTracker;
@@ -317,6 +322,12 @@ public class Extractor implements AutoCloseable {
                     }
                     this.maxEmbedDepth = Math.max(0, n);
                 });
+        options.valueIfPresent("maxEmbedSizeBytes").map(Long::parseLong).ifPresent(n -> {
+            if (n < 0) {
+                logger.warn("maxEmbedSizeBytes {} is negative; clamping to 0 (size guard disabled).", n);
+            }
+            this.maxEmbedSizeBytes = Math.max(0L, n);
+        });
         // Legacy naming and PST folder fan-out are mutually exclusive. The legacy global untitled_N
         // counter is serial-only: each fan-out fork carries its own counter starting at 0, so with
         // fan-out on the nameless embeds would get nondeterministic, non-matching names, defeating the
@@ -404,6 +415,7 @@ public class Extractor implements AutoCloseable {
     public int getPstParseParallelism() { return pstParseParallelism; }
     public boolean isLegacyUntitledNaming() { return legacyUntitledNaming; }
     public int getMaxEmbedDepth() { return maxEmbedDepth; }
+    public long getMaxEmbedSizeBytes() { return maxEmbedSizeBytes; }
 
     ExecutorService pstParseExecutorOrNull() { return pstParseExecutor; }
 
@@ -964,7 +976,7 @@ public class Extractor implements AutoCloseable {
                             embedTextResources, new MemoryPressureGauge(embedMemoryPressureThreshold),
                             this::ocrExecutor, !ocrDisabled, currentProgress, digester,
                             ocrFanout, ocrMinImageBytes, ocrParserClassName, sink, legacyUntitledNaming,
-                            maxEmbedDepth));
+                            maxEmbedDepth, maxEmbedSizeBytes));
             context.set(org.icij.extract.parser.PstFanoutConfig.class,
                     new org.icij.extract.parser.PstFanoutConfig(pstFolderFanout, this::pstParseExecutor));
         } else if (EmbedHandling.CONCATENATE == embedHandling) {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -41,6 +41,7 @@ import org.icij.extract.parser.HTML5Serializer;
 import org.icij.extract.parser.ParsingReaderWithContentHandler;
 import org.icij.extract.parser.ResourceClosingReader;
 import org.icij.extract.parser.ResilientOutlookPSTParser;
+import org.icij.extract.parser.ResumePolicy;
 import org.icij.extract.report.Reporter;
 import org.icij.spewer.MetadataTransformer;
 import org.icij.spewer.Spewer;
@@ -223,6 +224,10 @@ public class Extractor implements AutoCloseable {
     // Null until first use; created lazily by parseExecutor(), mirroring the OCR pool.
     private volatile ExecutorService pstParseExecutor = null;
     private ExtractionProgressTracker progressTracker;
+    // Per-file resume skip policy provider for RESUMABLE PST/OST extraction. Datashare installs a
+    // provider that returns, for a given file, a policy skipping the messages a previous run already
+    // durably indexed. Default: skip nothing, so non-resumed extraction is byte-for-byte unchanged.
+    private Function<Path, ResumePolicy> resumePolicyProvider = p -> ResumePolicy.NONE;
 
     /**
      * Create a new extractor, which will OCR images by default if Tesseract is available locally, extract inline
@@ -470,6 +475,17 @@ public class Extractor implements AutoCloseable {
     public ExtractionProgressTracker getProgressTracker() { return progressTracker; }
     public void addProgressListener(final ProgressListener listener) {
         progressTracker.addListener(listener);
+    }
+
+    /**
+     * Install a per-file resume skip policy provider for RESUMABLE PST/OST extraction. The provider
+     * is called with the file being extracted and returns a {@link ResumePolicy} that reports which
+     * of that file's mail messages a previous run already emitted and durably indexed, so this run
+     * skips re-parsing them. A {@code null} provider (or the default) resumes nothing. Consumed only
+     * by {@code ResilientOutlookPSTParser}; a no-op for every other file type.
+     */
+    public void setResumePolicyProvider(final Function<Path, ResumePolicy> provider) {
+        this.resumePolicyProvider = provider == null ? p -> ResumePolicy.NONE : provider;
     }
 
     /**
@@ -980,6 +996,9 @@ public class Extractor implements AutoCloseable {
                             maxEmbedDepth, maxEmbedSizeBytes));
             context.set(org.icij.extract.parser.PstFanoutConfig.class,
                     new org.icij.extract.parser.PstFanoutConfig(pstFolderFanout, this::pstParseExecutor));
+            // Per-file resume skip policy (default NONE). Only ResilientOutlookPSTParser reads it, so
+            // setting it here is a no-op for every non-PST file and never changes non-resumed runs.
+            context.set(ResumePolicy.class, resumePolicyProvider.apply(path));
         } else if (EmbedHandling.CONCATENATE == embedHandling) {
             context.set(Parser.class, parser);
             context.set(EmbeddedDocumentExtractor.class, new EmbedParser(rootDocument, context));

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -153,7 +153,8 @@ import static org.icij.extract.extractor.ArtifactUtils.getEmbeddedPath;
 @Option(name = "maxEmbedSizeBytes", description = "Maximum declared decompressed size, in bytes, of a " +
         "single embedded document to descend into. Embeds larger than this are skipped (recorded, not " +
         "parsed) to guard against decompression-bomb archives whose entries expand to multi-GiB. Only " +
-        "enforced when the embed's size is known. Defaults to 2 GiB. Set to 0 to disable.", parameter = "bytes")
+        "enforced when the embed's size is known. Disabled by default (0). Set to a positive byte " +
+        "count to enable.", parameter = "bytes")
 public class Extractor implements AutoCloseable {
 
     public static final String PAGES_JSON = "pages.json";

--- a/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
+++ b/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
@@ -92,6 +92,15 @@ public class ResilientOutlookPSTParser implements Parser {
     // Per-attachment recovery marker promoted by datashare into the typed Document.recoveryStatus
     // field. Value is one of RECOVERED | ENCRYPTED | UNRECOVERED.
     public static final String PST_ATTACHMENT_RECOVERY = "tika:pst_attachment_recovery";
+    // Stable, cross-run resumable key stamped on every emitted message: the message's descriptor
+    // node id. Datashare persists it once the message subtree is durably indexed and supplies a
+    // ResumePolicy that skips it on a later resumed run. Not read by DigestIdentifier, so stamping
+    // it never perturbs embed identity (see the resumable-OST design doc).
+    public static final String PST_RESUME_KEY = "tika:pst_resume_key";
+    // Count of messages skipped on this run because a ResumePolicy reported them already emitted and
+    // durably indexed by a previous run. Set on the root only when > 0, so a non-resumed run never
+    // carries a misleading "0".
+    public static final String PST_RESUMED_SKIPPED = "tika:pst_resumed_skipped";
 
     private static final long serialVersionUID = 1L;
     private static final Set<MediaType> SUPPORTED_TYPES = singleton(MS_OUTLOOK_PST_MIMETYPE);
@@ -117,7 +126,10 @@ public class ResilientOutlookPSTParser implements Parser {
         metadata.set(Metadata.CONTENT_TYPE, MS_OUTLOOK_PST_MIMETYPE.toString());
         final XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
         final Reconciliation reconciliation = new Reconciliation();
-        final EmissionContext emission = new EmissionContext(xhtml, extractor, reconciliation);
+        // Resume skip policy (default: skip nothing). Consulted per message in emitMessage.
+        final ResumePolicy resumePolicy =
+                context.get(ResumePolicy.class) != null ? context.get(ResumePolicy.class) : ResumePolicy.NONE;
+        final EmissionContext emission = new EmissionContext(xhtml, extractor, reconciliation, resumePolicy);
         final PstFanoutConfig fanout = context.get(PstFanoutConfig.class);
 
         xhtml.startDocument();
@@ -182,6 +194,7 @@ public class ResilientOutlookPSTParser implements Parser {
         PstStdoutFilter.runWithSuppressionLifted(() -> {
             recordReconciliation(metadata, pstPath, messageDescriptorIds, emission.emittedCount());
             recordAttachmentIntegrity(metadata, pstPath, emission);
+            recordResumeProgress(metadata, pstPath, emission);
         });
     }
 
@@ -273,7 +286,7 @@ public class ResilientOutlookPSTParser implements Parser {
                                     final EmissionContext baseEmission, final Reconciliation reconciliation) {
         final EmbedSpawner baseSpawner = (EmbedSpawner) baseEmission.extractor;
         final EmissionContext walkerEmission =
-                new EmissionContext(baseEmission.xhtml, baseSpawner.fork(), reconciliation);
+                new EmissionContext(baseEmission.xhtml, baseSpawner.fork(), reconciliation, baseEmission.resumePolicy);
         emitFolderMessages(folder, folderPath, walkerEmission);
     }
 
@@ -440,9 +453,19 @@ public class ResilientOutlookPSTParser implements Parser {
         if (!emission.markEmitted(descriptorId)) {
             return;
         }
+        // Resume: a unit a previous run already emitted and durably indexed is skipped WITHOUT
+        // re-parsing. It stays marked emitted (so orphan recovery does not re-reach it) and counts
+        // toward the emitted total (so reconciliation does not read it as loss); only the parse/emit
+        // work is elided. Inert unless a ResumePolicy is supplied (default resumes nothing), so a
+        // non-resumed run behaves exactly as before.
+        if (emission.isUnitDone(descriptorId)) {
+            emission.incrementEmitted();
+            emission.incrementResumeSkipped();
+            return;
+        }
         // subject is best-effort: it only feeds the resource name and the failure log.
         final String subject = safe(message::getSubject, null);
-        final Metadata metadata = buildMessageMetadata(folderPath, subject);
+        final Metadata metadata = buildMessageMetadata(folderPath, subject, descriptorId);
 
         final long estimatedSize = estimateSize(message);
         try (TikaInputStream messageStream = TikaInputStream.getFromContainer(message, estimatedSize, metadata)) {
@@ -615,11 +638,16 @@ public class ResilientOutlookPSTParser implements Parser {
 
     // Builds the per-message metadata that routes the body to PSTMailItemParser and
     // gives it a folder path and a resource name.
-    private Metadata buildMessageMetadata(final String folderPath, final String subject) {
+    private Metadata buildMessageMetadata(final String folderPath, final String subject, final long descriptorId) {
         final Metadata metadata = new Metadata();
         metadata.set(TikaCoreProperties.CONTENT_TYPE_PARSER_OVERRIDE, PSTMailItemParser.PST_MAIL_ITEM_STRING);
         metadata.set(PST.PST_FOLDER_PATH, folderPath);
         metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, resourceName(subject));
+        // Stable, cross-run resumable key: datashare persists it once this message's subtree is
+        // durably indexed, then supplies a ResumePolicy that skips it on a later resumed run. Not
+        // read by DigestIdentifier (which uses only the content hash, parent id, relationship id and
+        // resource name), so stamping it never perturbs this message's or its attachments' ids.
+        metadata.set(PST_RESUME_KEY, Long.toString(descriptorId));
         return metadata;
     }
 
@@ -695,6 +723,19 @@ public class ResilientOutlookPSTParser implements Parser {
         }
     }
 
+    // Records, only on a resumed run that actually skipped something, how many messages were skipped
+    // because a previous run had already emitted and durably indexed them. Left absent otherwise so a
+    // non-resumed run never carries a misleading "0".
+    private void recordResumeProgress(final Metadata metadata, final String pstPath,
+                                      final EmissionContext emission) {
+        final int skipped = emission.resumeSkipped();
+        if (skipped > 0) {
+            metadata.set(PST_RESUMED_SKIPPED, Integer.toString(skipped));
+            logger.info("PST resume for \"{}\": skipped {} message(s) already emitted by a previous run.",
+                    pstPath, skipped);
+        }
+    }
+
     // Closes the underlying file handle, ignoring close-time failures: by the time we
     // get here the content is already emitted, so a failing close must not mask it.
     private static void closeQuietly(final PSTFile pstFile) {
@@ -758,6 +799,7 @@ public class ResilientOutlookPSTParser implements Parser {
         private final AtomicInteger recoveredAttachments = new AtomicInteger();
         private final AtomicInteger unrecoveredAttachments = new AtomicInteger();
         private final AtomicInteger encryptedAttachments = new AtomicInteger();
+        private final AtomicInteger resumeSkipped = new AtomicInteger();
 
         boolean markEmitted(final long id) { return emittedDescriptorIds.add(id); }
         void unmarkEmitted(final long id) { emittedDescriptorIds.remove(id); }
@@ -774,6 +816,8 @@ public class ResilientOutlookPSTParser implements Parser {
         int unrecoveredAttachments() { return unrecoveredAttachments.get(); }
         void incrementEncryptedAttachments() { encryptedAttachments.incrementAndGet(); }
         int encryptedAttachments() { return encryptedAttachments.get(); }
+        void incrementResumeSkipped() { resumeSkipped.incrementAndGet(); }
+        int resumeSkipped() { return resumeSkipped.get(); }
     }
 
     // Mutable per-parse state shared by the folder walk, the orphan-recovery pass, and
@@ -783,13 +827,20 @@ public class ResilientOutlookPSTParser implements Parser {
         private final XHTMLContentHandler xhtml;
         private final EmbeddedDocumentExtractor extractor;
         private final Reconciliation reconciliation;
+        // Read-only, safe to share across fan-out forks: skip predicate for resumed runs.
+        private final ResumePolicy resumePolicy;
 
         private EmissionContext(final XHTMLContentHandler xhtml, final EmbeddedDocumentExtractor extractor,
-                                final Reconciliation reconciliation) {
+                                final Reconciliation reconciliation, final ResumePolicy resumePolicy) {
             this.xhtml = xhtml;
             this.extractor = extractor;
             this.reconciliation = reconciliation;
+            this.resumePolicy = resumePolicy;
         }
+
+        private boolean isUnitDone(final long resumeKey) { return resumePolicy.isUnitDone(resumeKey); }
+        private void incrementResumeSkipped() { reconciliation.incrementResumeSkipped(); }
+        private int resumeSkipped() { return reconciliation.resumeSkipped(); }
 
         private void enableAttachmentIntegrityCheck() { reconciliation.enableAttachmentIntegrityCheck(); }
         private boolean shouldCheckAttachmentIntegrity() { return reconciliation.shouldCheckAttachmentIntegrity(); }

--- a/extract-lib/src/main/java/org/icij/extract/parser/ResumePolicy.java
+++ b/extract-lib/src/main/java/org/icij/extract/parser/ResumePolicy.java
@@ -1,0 +1,34 @@
+package org.icij.extract.parser;
+
+/**
+ * Skip policy for RESUMABLE extraction of a single large PST/OST mailbox.
+ *
+ * <p>Carried through the Tika {@link org.apache.tika.parser.ParseContext} (like
+ * {@link PstFanoutConfig}) and consulted by {@link ResilientOutlookPSTParser} before it emits each
+ * mail message. When a caller supplies a policy that reports a unit as already done, the parser
+ * skips re-parsing and re-emitting that unit; a restart therefore does not reparse a giant mailbox
+ * from byte 0.
+ *
+ * <p>The persistence of "which units are done" is deliberately NOT here: only the consumer of the
+ * emitted documents (Datashare) knows when a document has been durably indexed. Datashare records
+ * completed keys and hands the parser a {@code ResumePolicy} built from that set on a resumed run.
+ *
+ * <p>Off by default: with no policy in the context (or {@link #NONE}), nothing is skipped and a
+ * non-resumed run is byte-for-byte unchanged.
+ */
+@FunctionalInterface
+public interface ResumePolicy {
+
+    /** A policy that resumes nothing: every unit is treated as not-yet-done. The default. */
+    ResumePolicy NONE = resumeKey -> false;
+
+    /**
+     * @param resumeKey the stable, cross-run resumable key of a work unit. For PST/OST this is a
+     *                  mail message's descriptor node id ({@code PSTMessage.getDescriptorNodeId()}),
+     *                  a property of the mailbox's bytes and thus identical every run.
+     * @return {@code true} if this unit was already emitted and durably indexed by a previous run,
+     *         so the current run may skip re-parsing and re-emitting it. MUST be a pure function of
+     *         the key (side-effect free) and stable for the lifetime of one extraction.
+     */
+    boolean isUnitDone(long resumeKey);
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
@@ -1,0 +1,126 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.io.TemporaryResources;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.BodyContentHandler;
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.TikaDocument;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class EmbedSpawnerSizeGuardTest {
+
+    private TikaDocument root(final String path) {
+        return new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", Charset.defaultCharset()))
+                .create(Paths.get(path));
+    }
+
+    // Serial spawner with the depth guard disabled and an explicit, small decompressed-size cap and no
+    // output path (no spooling), so only the size guard is under test.
+    private EmbedSpawner spawnerWithSize(final TikaDocument root, final long maxEmbedSizeBytes) {
+        return new EmbedSpawner(root, new ParseContext(), null,
+                w -> new BodyContentHandler(w),
+                64L * 1024 * 1024, new TemporaryResources(), () -> false, 0, maxEmbedSizeBytes);
+    }
+
+    private TikaDocument parent() {
+        return new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", StandardCharsets.UTF_8))
+                .create(Paths.get("/tmp/parent"));
+    }
+
+    private Metadata nonInline(final String name, final Long contentLength) {
+        final Metadata m = new Metadata();
+        m.set(org.apache.tika.metadata.TikaCoreProperties.RESOURCE_NAME_KEY, name);
+        if (contentLength != null) {
+            m.set(Metadata.CONTENT_LENGTH, Long.toString(contentLength));
+        }
+        return m;
+    }
+
+    @Test
+    public void testEmbedBeyondSizeIsRefusedAndRecorded() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // Declared decompressed size (1000) exceeds the 100-byte cap: the embed is refused.
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("bomb.bin", 1000L), false);
+
+        // Refused: no embed added to the parent, and the skip is recorded on the parent.
+        assertThat(parent.getEmbeds()).isEmpty();
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isEqualTo("1");
+    }
+
+    @Test
+    public void testSecondRefusedEmbedIncrementsParentMarker() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        spawner.parseEmbedded(new ByteArrayInputStream("a".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("bomb1.bin", 1000L), false);
+        spawner.parseEmbedded(new ByteArrayInputStream("b".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("bomb2.bin", 2000L), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isEqualTo("2");
+        assertThat(parent.getEmbeds()).isEmpty();
+    }
+
+    @Test
+    public void testUnderCapEmbedStillExtracts() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // Declared decompressed size (50) is under the 100-byte cap: the embed takes the normal spawn path.
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("real.bin", 50L), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
+        assertThat(parent.getEmbeds()).isNotEmpty();
+    }
+
+    @Test
+    public void testUnknownSizeIsNotGuarded() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 100L);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // No CONTENT_LENGTH on the embed: size is unknown, so the guard does not fire (do not guess).
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("unknown.bin", null), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
+        assertThat(parent.getEmbeds()).isNotEmpty();
+    }
+
+    @Test
+    public void testGuardDisabledWhenSizeIsZero() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        final EmbedSpawner spawner = spawnerWithSize(root, 0L); // disabled
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // Even a huge declared size is not refused when the cap is disabled (cap <= 0).
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("huge.bin", 10L * 1024 * 1024 * 1024), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
+        assertThat(parent.getEmbeds()).isNotEmpty();
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerSizeGuardTest.java
@@ -32,6 +32,14 @@ public class EmbedSpawnerSizeGuardTest {
                 64L * 1024 * 1024, new TemporaryResources(), () -> false, 0, maxEmbedSizeBytes);
     }
 
+    // Serial spawner with the depth guard disabled and NO explicit size cap, so it carries the shipped
+    // default (DEFAULT_MAX_EMBED_SIZE_BYTES). Used to assert the guard is off unless opted into.
+    private EmbedSpawner spawnerWithDefaultSize(final TikaDocument root) {
+        return new EmbedSpawner(root, new ParseContext(), null,
+                w -> new BodyContentHandler(w),
+                64L * 1024 * 1024, new TemporaryResources(), () -> false, 0);
+    }
+
     private TikaDocument parent() {
         return new DocumentFactory()
                 .withIdentifier(new DigestIdentifier("SHA-256", StandardCharsets.UTF_8))
@@ -117,6 +125,24 @@ public class EmbedSpawnerSizeGuardTest {
         spawner.pushForTest(parent);
 
         // Even a huge declared size is not refused when the cap is disabled (cap <= 0).
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("huge.bin", 10L * 1024 * 1024 * 1024), false);
+
+        assertThat(parent.getMetadata().get(EmbedSpawner.EMBEDS_SKIPPED_MAX_SIZE)).isNull();
+        assertThat(parent.getEmbeds()).isNotEmpty();
+    }
+
+    @Test
+    public void testGuardDisabledByDefault() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.zip");
+        // No explicit cap: the spawner carries the shipped default, which is disabled (opt-in guard).
+        final EmbedSpawner spawner = spawnerWithDefaultSize(root);
+        final TikaDocument parent = parent();
+        spawner.pushForTest(parent);
+
+        // The default must be disabled, so even a huge declared size is extracted, not skipped: a
+        // legitimate multi-GiB attachment is never silently dropped unless an operator opts in.
+        assertThat(spawner.maxEmbedSizeBytesForTest()).isEqualTo(0L);
         spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
                 new BodyContentHandler(), nonInline("huge.bin", 10L * 1024 * 1024 * 1024), false);
 

--- a/extract-lib/src/test/java/org/icij/extract/parser/ResilientOutlookPSTParserResumeTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/parser/ResilientOutlookPSTParserResumeTest.java
@@ -1,0 +1,205 @@
+package org.icij.extract.parser;
+
+import org.apache.tika.extractor.EmbeddedDocumentExtractor;
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.Parser;
+import org.apache.tika.sax.BodyContentHandler;
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.TikaDocument;
+import org.icij.extract.extractor.Extractor;
+import org.icij.spewer.FieldNames;
+import org.icij.spewer.Spewer;
+import org.icij.task.Options;
+import org.junit.Test;
+import org.xml.sax.ContentHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Resumable-extraction seam (plan item 2.4). Proves that supplying a {@link ResumePolicy} skips the
+ * mail messages a previous run already emitted, without re-parsing them and without perturbing the
+ * ids of the messages that ARE emitted; and that the seam is inert by default.
+ */
+public class ResilientOutlookPSTParserResumeTest {
+
+    private Path testPst() throws Exception {
+        return Paths.get(getClass().getResource("/documents/pst/testPST.pst").toURI());
+    }
+
+    // Records, per emitted mail item, its stamped resume key. mailItems holds one entry per emitted
+    // message (so its size is the number of messages actually parsed, not skipped).
+    private static class ResumeRecordingExtractor implements EmbeddedDocumentExtractor {
+        final List<String> resumeKeys = new ArrayList<>();
+
+        public boolean shouldParseEmbedded(Metadata metadata) { return true; }
+
+        public void parseEmbedded(InputStream stream, ContentHandler handler, Metadata metadata, boolean outputHtml) {
+            String override = metadata.get(TikaCoreProperties.CONTENT_TYPE_PARSER_OVERRIDE);
+            if (override != null && override.contains("pst-mail-item")) {
+                resumeKeys.add(metadata.get(ResilientOutlookPSTParser.PST_RESUME_KEY));
+            }
+        }
+    }
+
+    private static Metadata parse(Path file, ResumePolicy policy, ResumeRecordingExtractor rec) throws Exception {
+        ResilientOutlookPSTParser parser = new ResilientOutlookPSTParser();
+        ParseContext context = new ParseContext();
+        context.set(Parser.class, parser);
+        context.set(EmbeddedDocumentExtractor.class, rec);
+        if (policy != null) {
+            context.set(ResumePolicy.class, policy);
+        }
+        Metadata metadata = new Metadata();
+        try (InputStream is = TikaInputStream.get(file, metadata)) {
+            parser.parse(is, new BodyContentHandler(-1), metadata, context);
+        }
+        return metadata;
+    }
+
+    @Test
+    public void test_no_policy_emits_every_message_and_stamps_a_distinct_resume_key() throws Exception {
+        ResumeRecordingExtractor rec = new ResumeRecordingExtractor();
+        Metadata metadata = parse(testPst(), null, rec);
+
+        // All 7 messages parsed; no resume happened.
+        assertThat(rec.resumeKeys).hasSize(7);
+        assertThat(metadata.get(ResilientOutlookPSTParser.PST_EMITTED)).isEqualTo("7");
+        assertThat(metadata.get(ResilientOutlookPSTParser.PST_RESUMED_SKIPPED)).isNull();
+        // Every emitted message carries a distinct, parseable resume key.
+        Set<Long> distinct = new HashSet<>();
+        for (String key : rec.resumeKeys) {
+            assertThat(key).isNotNull();
+            distinct.add(Long.parseLong(key));
+        }
+        assertThat(distinct).hasSize(7);
+    }
+
+    @Test
+    public void test_policy_skipping_all_units_parses_nothing_but_reconciles_honestly() throws Exception {
+        ResumeRecordingExtractor rec = new ResumeRecordingExtractor();
+        Metadata metadata = parse(testPst(), key -> true, rec);
+
+        // No message was parsed/emitted...
+        assertThat(rec.resumeKeys).isEmpty();
+        // ...yet reconciliation still accounts for all 7 (they are in the index from a previous run),
+        // so a resumed run does not read as catastrophic loss.
+        assertThat(metadata.get(ResilientOutlookPSTParser.PST_EXPECTED)).isEqualTo("7");
+        assertThat(metadata.get(ResilientOutlookPSTParser.PST_EMITTED)).isEqualTo("7");
+        assertThat(metadata.get(ResilientOutlookPSTParser.PST_FAILED)).isEqualTo("0");
+        assertThat(metadata.get(ResilientOutlookPSTParser.PST_RESUMED_SKIPPED)).isEqualTo("7");
+    }
+
+    @Test
+    public void test_policy_skipping_a_subset_emits_exactly_the_complement() throws Exception {
+        // First pass: learn the stable resume keys stamped on each message.
+        ResumeRecordingExtractor firstPass = new ResumeRecordingExtractor();
+        parse(testPst(), null, firstPass);
+        List<Long> allKeys = new ArrayList<>();
+        for (String k : firstPass.resumeKeys) {
+            allKeys.add(Long.parseLong(k));
+        }
+        assertThat(allKeys).hasSize(7);
+
+        // Mark the first three as already done by a previous run.
+        Set<Long> done = new HashSet<>(allKeys.subList(0, 3));
+        assertThat(done).hasSize(3);
+
+        // Second pass: only the complement (4 messages) must be parsed, and none of them may be a
+        // done key.
+        ResumeRecordingExtractor resumed = new ResumeRecordingExtractor();
+        Metadata metadata = parse(testPst(), done::contains, resumed);
+
+        assertThat(resumed.resumeKeys).hasSize(4);
+        for (String k : resumed.resumeKeys) {
+            assertThat(done).excludes(Long.parseLong(k));
+        }
+        assertThat(metadata.get(ResilientOutlookPSTParser.PST_EMITTED)).isEqualTo("7");
+        assertThat(metadata.get(ResilientOutlookPSTParser.PST_RESUMED_SKIPPED)).isEqualTo("3");
+        assertThat(metadata.get(ResilientOutlookPSTParser.PST_FAILED)).isEqualTo("0");
+    }
+
+    // ---- End-to-end id determinism through Extractor (fan-out on, OCR off) ------------------------
+
+    // Thread-safe recorder of every written document's id, plus the resume key of message docs.
+    private static class IdRecordingSpewer extends Spewer {
+        final List<String> allIds = new CopyOnWriteArrayList<>();
+        // resumeKey -> the message document's own id (message docs only).
+        final Map<Long, String> messageIdByResumeKey = new java.util.concurrent.ConcurrentHashMap<>();
+
+        IdRecordingSpewer() { super(new FieldNames()); }
+
+        @Override
+        protected void writeDocument(TikaDocument doc, TikaDocument parent, TikaDocument root, int level) throws IOException {
+            try { Spewer.toString(doc.getReader()); } catch (Exception ignored) { /* drive the parse */ }
+            allIds.add(doc.getId());
+            String key = doc.getMetadata().get(ResilientOutlookPSTParser.PST_RESUME_KEY);
+            if (key != null) {
+                messageIdByResumeKey.put(Long.parseLong(key), doc.getId());
+            }
+        }
+    }
+
+    private IdRecordingSpewer extractWith(ResumePolicy policy) throws Exception {
+        IdRecordingSpewer spewer = new IdRecordingSpewer();
+        // A DigestIdentifier (as datashare uses) gives embeds content-derived ids; the default
+        // PathIdentifier would return the root path for every embed, defeating the determinism check.
+        final DocumentFactory factory = new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA256", java.nio.charset.StandardCharsets.UTF_8));
+        try (Extractor extractor = new Extractor(factory, Options.from(Map.of(
+                "ocr", "false", "progressHeartbeatInterval", "0")))) {
+            if (policy != null) {
+                extractor.setResumePolicyProvider(p -> policy);
+            }
+            extractor.extract(testPst(), spewer);
+        }
+        return spewer;
+    }
+
+    @Test
+    public void test_resumed_run_ids_are_a_strict_subset_of_the_full_run_ids() throws Exception {
+        // Full run: capture every emitted id and the message ids by resume key.
+        IdRecordingSpewer full = extractWith(null);
+        assertThat(full.messageIdByResumeKey).hasSize(7);
+
+        // Skip two messages on the resumed run.
+        List<Long> keys = new ArrayList<>(full.messageIdByResumeKey.keySet());
+        Collections.sort(keys);
+        Set<Long> done = new HashSet<>(keys.subList(0, 2));
+        IdRecordingSpewer resumed = extractWith(done::contains);
+
+        Set<String> fullIds = new HashSet<>(full.allIds);
+        Set<String> resumedIds = new HashSet<>(resumed.allIds);
+
+        // Determinism: skipping perturbs NO surviving id. Every id written on the resumed run was
+        // also written on the full run (subset), and the resumed run wrote strictly fewer documents.
+        assertThat(fullIds.containsAll(resumedIds)).isTrue();
+        assertThat(resumedIds.size()).isLessThan(fullIds.size());
+
+        // The two skipped messages' own ids are absent from the resumed run.
+        for (Long skippedKey : done) {
+            assertThat(resumedIds).excludes(full.messageIdByResumeKey.get(skippedKey));
+        }
+        // The surviving five message ids are present in both runs, byte-identical.
+        for (Long key : keys) {
+            if (!done.contains(key)) {
+                assertThat(resumedIds).contains(full.messageIdByResumeKey.get(key));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Groundwork for resuming a large PST/OST interrupted mid-parse instead of restarting it from scratch; a 50 GB mailbox cost ~17h of wasted re-processing last run. Extraction-side hook only, inert until the datashare side persists progress, so behavior is unchanged for now.