### PR TITLE
fix(embed): log embedded parse failures at WARN without stack trace

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedParser.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedParser.java
@@ -98,8 +98,13 @@ public class EmbedParser extends ParsingEmbeddedDocumentExtractor {
 					metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY), metadata.get(Metadata.CONTENT_TYPE), root);
 			NoContentReason.stamp(metadata, NoContentReason.EMPTY_FILE);
 		} catch (final TikaException e) {
-			logger.error("Unable to parse embedded document: \"{}\" ({}) (in \"{}\").",
-					metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY), metadata.get(Metadata.CONTENT_TYPE), root, e);
+			// A malformed embedded entry (corrupt XML, unsupported image, nested zip bomb, ...) is a
+			// per-document data quirk, not a datashare fault: the parent document still parses and the
+			// failing entry is skipped. Log a single WARN line without the stack trace to keep the ARTIFACT
+			// log readable on large corpora; the full filtered trace is preserved on the document metadata
+			// below for anyone who needs to investigate a specific file.
+			logger.warn("Unable to parse embedded document: \"{}\" ({}) (in \"{}\").",
+					metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY), metadata.get(Metadata.CONTENT_TYPE), root);
 			metadata.add(TikaCoreProperties.TIKA_META_EXCEPTION_EMBEDDED_STREAM,
 					ExceptionUtils.getFilteredStackTrace(e));
 		}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedParserMarkerTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedParserMarkerTest.java
@@ -14,13 +14,20 @@ import org.icij.extract.document.DigestIdentifier;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.document.TikaDocument;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.ContentHandler;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -75,5 +82,28 @@ public class EmbedParserMarkerTest {
         Metadata metadata = parseWith(new TikaException("boom"));
         assertThat(metadata.get(NoContentReason.METADATA_KEY)).isNull();
         assertThat(metadata.get(TikaCoreProperties.TIKA_META_EXCEPTION_EMBEDDED_STREAM)).isNotNull();
+    }
+
+    @Test
+    public void testGenuineParseFailureLogsAtWarnWithoutStacktrace() throws Exception {
+        Logger embedLogger = (Logger) LoggerFactory.getLogger(EmbedParser.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        embedLogger.addAppender(appender);
+        try {
+            parseWith(new TikaException("boom"));
+        } finally {
+            embedLogger.detachAppender(appender);
+        }
+
+        List<ILoggingEvent> events = appender.list.stream()
+                .filter(e -> e.getFormattedMessage().startsWith("Unable to parse embedded document"))
+                .toList();
+        assertThat(events).hasSize(1);
+        // benign per-embedded-document failure: a single WARN line, not an ERROR, and no attached
+        // stack trace (the exception is already preserved into the document metadata). This is what
+        // keeps the ARTIFACT log from being dominated by tens of thousands of full stack traces.
+        assertThat(events.get(0).getLevel()).isEqualTo(Level.WARN);
+        assertThat(events.get(0).getThrowableProxy()).isNull();
     }
 }


### PR DESCRIPTION
A malformed embedded entry (corrupt XML, unsupported image, nested zip bomb) is a per-document data quirk, not a datashare fault: the parent document still parses and the failing entry is skipped. `EmbedParser` was logging each one at ERROR with a full stack trace, which dominated the ARTIFACT logs on large corpora (a recent 105MB run was ~73% stack-trace frames from this single statement). The filtered trace is already preserved on the document metadata, so downgrading the log line loses nothing.

- fix: log the embedded parse failure at WARN with a single line instead of ERROR with a stack trace
- test: assert the failure logs at WARN with no attached throwable