### PR TITLE
fix(extract): do not retain embed tree during streaming spew

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/document/TikaDocument.java
+++ b/extract-lib/src/main/java/org/icij/extract/document/TikaDocument.java
@@ -194,6 +194,17 @@ public class TikaDocument {
 		return addEmbed(new EmbeddedTikaDocument(this, metadata));
 	}
 
+	/**
+	 * Create an embedded document parented to this one WITHOUT retaining it in this document's embeds
+	 * list. Streaming spew writes every embed as it is produced and never re-walks the tree, so keeping
+	 * embeds linked would grow the heap O(n) with the embed count and OOM a large container (a PST/OST
+	 * with hundreds of thousands of items). The parent pointer still lets the embed resolve its id and
+	 * metadata chain. See StreamingEmbedRetentionTest.
+	 */
+	public EmbeddedTikaDocument newDetachedEmbed(final Metadata metadata) {
+		return new EmbeddedTikaDocument(this, metadata);
+	}
+
 	private EmbeddedTikaDocument addEmbed(final Identifier identifier, final Path path, final Metadata metadata) {
 		return addEmbed(new EmbeddedTikaDocument(this, identifier, path, metadata));
 	}

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -398,7 +398,11 @@ public class EmbedSpawner extends EmbedParser {
 		if (sink != null) {
 			sink.promise();
 		}
-		final EmbeddedTikaDocument embed = spewParent.addEmbed(metadata);
+		// Streaming spew writes each embed as it is produced and never re-walks the tree, so it must
+		// not retain embeds under their parent (that grows the heap O(n) and OOMs large containers).
+		final EmbeddedTikaDocument embed = sink != null
+				? spewParent.newDetachedEmbed(metadata)
+				: spewParent.addEmbed(metadata);
 
 		// The reader is generated lazily during the spew walk, reading from memory or the
 		// temp file depending on whether this embed spilled.
@@ -482,7 +486,10 @@ public class EmbedSpawner extends EmbedParser {
 		if (sink != null) {
 			sink.promise();
 		}
-		final EmbeddedTikaDocument embed = spewParent.addEmbed(metadata);
+		// Streaming spew must not retain embeds under their parent (see the sibling spawn path).
+		final EmbeddedTikaDocument embed = sink != null
+				? spewParent.newDetachedEmbed(metadata)
+				: spewParent.addEmbed(metadata);
 
 		String name = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
 		if (null == name || name.isEmpty()) {

--- a/extract-lib/src/test/java/org/icij/extract/extractor/StreamingEmbedRetentionTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/StreamingEmbedRetentionTest.java
@@ -1,0 +1,52 @@
+package org.icij.extract.extractor;
+
+import org.icij.extract.document.TikaDocument;
+import org.icij.spewer.FieldNames;
+import org.icij.spewer.Spewer;
+import org.icij.task.Options;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Streaming spew must not retain the parsed embed tree in memory: every embed is written to the
+ * spewer as it is produced, and the streaming path never re-walks {@code root.getEmbeds()}. Keeping
+ * the embeds linked under their parent grows the heap O(n) with the number of embedded documents,
+ * which is what OOMs a large container (a PST/OST with hundreds of thousands of items).
+ */
+public class StreamingEmbedRetentionTest {
+
+    private static final String FIXTURE = "/documents/image_attachment.eml";
+
+    /** Captures the root document handed to the spewer so we can inspect its embed list afterwards. */
+    private static class RootCapturingSpewer extends Spewer {
+        final AtomicReference<TikaDocument> root = new AtomicReference<>();
+        RootCapturingSpewer() { super(new FieldNames()); }
+        @Override
+        protected void writeDocument(TikaDocument doc, TikaDocument parent, TikaDocument r, int level) throws IOException {
+            try { Spewer.toString(doc.getReader()); } catch (Exception ignored) {}
+            if (parent == null) {
+                root.set(doc);
+            }
+        }
+    }
+
+    @Test
+    public void testStreamingDoesNotRetainEmbedsOnRoot() throws Exception {
+        RootCapturingSpewer spewer = new RootCapturingSpewer();
+        try (Extractor extractor = new Extractor(Options.from(Map.of(
+                "streamingSpew", "true",
+                "ocrParallelism", "4", "ocrFanout", "true", "progressHeartbeatInterval", "0")))) {
+            extractor.extract(Paths.get(getClass().getResource(FIXTURE).getPath()), spewer);
+        }
+        assertThat(spewer.root.get()).isNotNull();
+        // The fixture has at least one embedded document; streaming must have written it without
+        // keeping it linked under the root, so the retained tree is empty once the parse ends.
+        assertThat(spewer.root.get().hasEmbeds()).isFalse();
+    }
+}


### PR DESCRIPTION
When streaming spew is enabled (the default), every embedded document is written to the spewer as it is produced and the tree is never re-walked. `EmbedSpawner` was still linking each embed under its parent and never releasing it, so the retained `TikaDocument`+`Metadata` objects grew O(n) with the embed count. A large container (a PST/OST with hundreds of thousands of items) exhausts the heap this way, especially when a long or timed-out parse keeps producing embeds. The legacy buffer-then-walk path is unchanged.

- fix: add `TikaDocument.newDetachedEmbed` that parents an embed without retaining it in the embeds list
- fix: use it from both `EmbedSpawner` spawn paths when a streaming sink is present
- test: assert a streaming extraction leaves no embeds retained on the root