### PR TITLE
fix(extract): abort embedded extraction promptly on cancellation

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -323,6 +323,17 @@ public class EmbedSpawner extends EmbedParser {
 	public void parseEmbedded(final InputStream input, final ContentHandler handler, final Metadata metadata,
 	                          final boolean outputHtml) throws SAXException, IOException {
 
+		// Cooperative cancellation point. Extractor's parse-timeout cancels the parse with
+		// future.cancel(true), which interrupts this thread; a parser stuck producing embeds (a huge
+		// PST/OST) would otherwise keep spawning them long after the task gave up, accumulating memory
+		// with no consumer. Abort at each embed boundary instead. The interrupt flag is deliberately
+		// left set so every subsequent embed on this parse also aborts, even if a Tika container parser
+		// swallows an individual throw.
+		if (Thread.currentThread().isInterrupted()) {
+			throw new InterruptedIOException("embedded extraction cancelled (thread interrupted): "
+					+ metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY));
+		}
+
 		// There's no need to spawn inline embeds, like images in PDFs. These should be concatenated to the main
 		// document as usual.
 		if (TikaCoreProperties.EmbeddedResourceType.INLINE.toString().equals(metadata.get(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE))) {

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerCancellationTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerCancellationTest.java
@@ -1,0 +1,76 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.io.TemporaryResources;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.BodyContentHandler;
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.TikaDocument;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InterruptedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * When a parse is cancelled, Extractor's parse-timeout does {@code future.cancel(true)}, which
+ * interrupts the parse thread. EmbedSpawner must treat that interrupt as a cancellation point and
+ * abort at the next embedded document instead of continuing to produce embeds (which, once the spew
+ * worker has stopped draining, accumulate and drive the process into OOM).
+ */
+public class EmbedSpawnerCancellationTest {
+
+    private TikaDocument root(final String path) {
+        return new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", Charset.defaultCharset()))
+                .create(Paths.get(path));
+    }
+
+    private EmbedSpawner serialSpawner(final TikaDocument root) {
+        // depth guard disabled (0) and no output path, so parseEmbedded reaches the spawn path
+        // unless the cancellation check short-circuits it first.
+        return new EmbedSpawner(root, new ParseContext(), null,
+                w -> new BodyContentHandler(w),
+                64L * 1024 * 1024, new TemporaryResources(), () -> false, 0);
+    }
+
+    private Metadata nonInline(final String name) {
+        final Metadata m = new Metadata();
+        m.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+        return m;
+    }
+
+    @Test
+    public void testInterruptedParseAbortsBeforeSpawningEmbed() throws Exception {
+        final TikaDocument root = root("/tmp/fake-root.pst");
+        final EmbedSpawner spawner = serialSpawner(root);
+        final TikaDocument parent = new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", StandardCharsets.UTF_8))
+                .create(Paths.get("/tmp/parent"));
+        spawner.pushForTest(parent);
+
+        Thread.currentThread().interrupt(); // simulate future.cancel(true) on parse-timeout
+        boolean threw = false;
+        try {
+            spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                    new BodyContentHandler(), nonInline("attachment.bin"), false);
+        } catch (final InterruptedIOException expected) {
+            threw = true;
+            // The interrupt flag must stay set so any subsequent embed on this parse also aborts,
+            // even if a Tika container parser swallows an individual throw.
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted(); // clear so we don't poison the test-runner thread
+        }
+
+        assertThat(threw).isTrue();
+        // No embed was spawned: the parse aborted before doing any work.
+        assertThat(parent.getEmbeds()).isEmpty();
+    }
+}


### PR DESCRIPTION
Extractor's parse-timeout cancels a runaway parse with `future.cancel(true)`, which interrupts the parse thread, but nothing in the embed-production path acted on that interrupt. A parser stuck producing embeds from a huge PST/OST kept spawning them long after the task gave up, accumulating memory with no consumer (the spew worker had already stopped draining). This adds a cancellation point at each embedded-document boundary.

- fix: `EmbedSpawner.parseEmbedded` throws `InterruptedIOException` when the thread is interrupted, before spooling or spawning
- fix: leave the interrupt flag set so every subsequent embed also aborts, even if a Tika container parser swallows an individual throw
- test: an interrupted parse aborts before spawning and spawns no embed

Note: a parser spinning in a pure native CPU loop that never re-enters `parseEmbedded` still cannot be interrupted here; hard-killing that requires process isolation and is out of scope.