### PR TITLE
fix(extract): write root stub on aborted streaming parse to avoid orphaned embeds

### DIFF
--- a/extract-lib/src/main/java/org/icij/spewer/Spewer.java
+++ b/extract-lib/src/main/java/org/icij/spewer/Spewer.java
@@ -56,6 +56,19 @@ public abstract class Spewer implements AutoCloseable, Serializable {
 
     protected abstract void writeDocument(TikaDocument doc, TikaDocument parent, TikaDocument root, int level) throws IOException;
 
+    /**
+     * Write a minimal, contentless "stub" for a container ROOT whose full write never happened because
+     * the parse was aborted (timeout/cancel/crash) after some of its embeds had already been streamed to
+     * the index. Writing the stub keeps those embeds from being orphaned under a root that does not
+     * exist; a later re-run of the stage replaces the stub with the fully-parsed root.
+     *
+     * <p>Default no-op: only index-backed spewers, where orphaning is observable, need to act. Called at
+     * most once per aborted root, after the streaming spew worker has drained.
+     */
+    protected void writeRootStub(final TikaDocument root) throws IOException {
+        // no-op by default
+    }
+
     public void write(final TikaDocument document) throws IOException {
         try {
             writeDocument(document, null, null, 0);

--- a/extract-lib/src/main/java/org/icij/spewer/Spewer.java
+++ b/extract-lib/src/main/java/org/icij/spewer/Spewer.java
@@ -64,8 +64,12 @@ public abstract class Spewer implements AutoCloseable, Serializable {
      *
      * <p>Default no-op: only index-backed spewers, where orphaning is observable, need to act. Called at
      * most once per aborted root, after the streaming spew worker has drained.
+     *
+     * @param root            the container root whose full write never happened
+     * @param writtenChildren the number of embedded children actually written to the endpoint before
+     *                        the abort, so the stub can record how much of the container was recovered
      */
-    protected void writeRootStub(final TikaDocument root) throws IOException {
+    protected void writeRootStub(final TikaDocument root, final long writtenChildren) throws IOException {
         // no-op by default
     }
 

--- a/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
+++ b/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
@@ -206,7 +206,7 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
             return;
         }
         try {
-            spewer.writeRootStub(root);
+            spewer.writeRootStub(root, writtenEmbeds.get());
             rootWritten = true;
         } catch (final Throwable t) {
             logger.error("failed to write root stub for aborted parse of {}", root.getId(), t);

--- a/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
+++ b/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
@@ -33,9 +33,15 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
     private final BlockingQueue<Object> queue;
     private final AtomicLong promised = new AtomicLong();
     private final AtomicLong completed = new AtomicLong();
+    private final AtomicLong writtenEmbeds = new AtomicLong();
     private final Object drainLock = new Object();
     private volatile Throwable workerError;
     private volatile Thread worker;
+    // The root the streamed embeds belong to, captured off the worker as it writes them, so that on an
+    // aborted parse (the foreground never reaches spew()) close() can still write a root stub and keep
+    // those embeds from being orphaned. rootWritten is set once the real root is written by spew().
+    private volatile TikaDocument seenRoot;
+    private volatile boolean rootWritten;
 
     public StreamingSpewCoordinator(final Spewer spewer, final int queueCapacity) {
         this.spewer = spewer;
@@ -87,6 +93,7 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
         Throwable rootError = null;
         try {
             spewer.writeDocument(root, null, null, 0);
+            rootWritten = true;
         } catch (final Throwable t) {
             rootError = t;
         } finally {
@@ -112,10 +119,14 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
                     return;
                 }
                 final SpewItem item = (SpewItem) o;
+                if (seenRoot == null) {
+                    seenRoot = item.root();
+                }
                 try {
                     // Skip children of a duplicate root, matching the legacy tree walk's gating.
                     if (!item.root().isDuplicate()) {
                         spewer.writeDocument(item.embed(), item.parent(), item.root(), item.level());
+                        writtenEmbeds.incrementAndGet();
                     }
                 } catch (final Throwable t) {
                     if (workerError == null) {
@@ -177,6 +188,29 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
     @Override
     public void close() {
         shutdownWorker();
+        writeRootStubIfOrphaned();
+    }
+
+    /**
+     * If the parse aborted before the foreground wrote the real root (spew() never ran to completion)
+     * yet embeds were already streamed to the index, write a contentless root stub so those embeds are
+     * not orphaned under a non-existent root. Best-effort and idempotent; runs after the worker drained,
+     * so writtenEmbeds/seenRoot are final. A duplicate root needs no stub (its children were skipped).
+     */
+    private void writeRootStubIfOrphaned() {
+        if (rootWritten) {
+            return;
+        }
+        final TikaDocument root = seenRoot;
+        if (root == null || root.isDuplicate() || writtenEmbeds.get() == 0) {
+            return;
+        }
+        try {
+            spewer.writeRootStub(root);
+            rootWritten = true;
+        } catch (final Throwable t) {
+            logger.error("failed to write root stub for aborted parse of {}", root.getId(), t);
+        }
     }
 
     private static void throwAsIO(final Throwable t) throws IOException {

--- a/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
+++ b/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
@@ -20,6 +20,7 @@ public class StreamingSpewCoordinatorTest {
     // A thread-safe recording spewer: records each written doc id and whether the root was a child write.
     private static class RecordingSpewer extends Spewer {
         final List<String> written = Collections.synchronizedList(new ArrayList<>());
+        final List<String> rootStubs = Collections.synchronizedList(new ArrayList<>());
         volatile boolean throwOnEmbed = false;
         volatile String failOnId = null;
 
@@ -34,6 +35,11 @@ public class StreamingSpewCoordinatorTest {
                 throw new IOException("boom writing specific ID " + doc.getId());
             }
             written.add(doc.getId());
+        }
+
+        @Override
+        protected void writeRootStub(TikaDocument root) {
+            rootStubs.add(root.getId());
         }
     }
 
@@ -63,6 +69,54 @@ public class StreamingSpewCoordinatorTest {
         // Root and both embeds written; the two embeds before await completes.
         assertThat(spewer.written).contains("root", "e1", "e2");
         assertThat(spewer.written).hasSize(3);
+    }
+
+    @Test
+    public void testWritesRootStubWhenParseAbortsBeforeRootIsWritten() throws Exception {
+        RecordingSpewer spewer = new RecordingSpewer();
+        TikaDocument root = doc("root", new StringReader("root-body"));
+        TikaDocument e1 = doc("e1", new StringReader("a"));
+
+        try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
+            // Production starts the worker before the parse; simulate that so the embed drains while
+            // the parse runs. The parse then throws (timeout/cancel) BEFORE the foreground wrote the
+            // root: spew(root) is never called; close() runs via try-with-resources.
+            coord.start();
+            coord.promise();
+            coord.ready(new SpewItem(e1, root, root, 1));
+        }
+
+        // The embed was written; the root would be orphaned, so close() must write a stub for it.
+        assertThat(spewer.written).contains("e1");
+        assertThat(spewer.rootStubs).contains("root");
+    }
+
+    @Test
+    public void testDoesNotWriteRootStubOnNormalCompletion() throws Exception {
+        RecordingSpewer spewer = new RecordingSpewer();
+        TikaDocument root = doc("root", new StringReader("root-body"));
+        TikaDocument e1 = doc("e1", new StringReader("a"));
+
+        try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
+            coord.promise();
+            coord.ready(new SpewItem(e1, root, root, 1));
+            coord.spew(root); // foreground writes the real root
+        }
+
+        // The real root was written; no stub is needed.
+        assertThat(spewer.written).contains("root", "e1");
+        assertThat(spewer.rootStubs).isEmpty();
+    }
+
+    @Test
+    public void testDoesNotWriteRootStubWhenNoEmbedsWereWritten() throws Exception {
+        RecordingSpewer spewer = new RecordingSpewer();
+
+        try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
+            // Parse aborted before producing any embed: nothing to orphan, so no stub.
+        }
+
+        assertThat(spewer.rootStubs).isEmpty();
     }
 
     @Test

--- a/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
+++ b/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
@@ -21,6 +21,7 @@ public class StreamingSpewCoordinatorTest {
     private static class RecordingSpewer extends Spewer {
         final List<String> written = Collections.synchronizedList(new ArrayList<>());
         final List<String> rootStubs = Collections.synchronizedList(new ArrayList<>());
+        final List<Long> rootStubChildCounts = Collections.synchronizedList(new ArrayList<>());
         volatile boolean throwOnEmbed = false;
         volatile String failOnId = null;
 
@@ -38,8 +39,9 @@ public class StreamingSpewCoordinatorTest {
         }
 
         @Override
-        protected void writeRootStub(TikaDocument root) {
+        protected void writeRootStub(TikaDocument root, long writtenChildren) {
             rootStubs.add(root.getId());
+            rootStubChildCounts.add(writtenChildren);
         }
     }
 
@@ -86,9 +88,11 @@ public class StreamingSpewCoordinatorTest {
             coord.ready(new SpewItem(e1, root, root, 1));
         }
 
-        // The embed was written; the root would be orphaned, so close() must write a stub for it.
+        // The embed was written; the root would be orphaned, so close() must write a stub for it,
+        // recording the number of children actually written (1) so the root can be marked partial.
         assertThat(spewer.written).contains("e1");
         assertThat(spewer.rootStubs).contains("root");
+        assertThat(spewer.rootStubChildCounts).containsOnly(1L);
     }
 
     @Test


### PR DESCRIPTION
In streaming spew the embedded children are written to the index as they are parsed, and the container ROOT is written last (a PST/OST emits no root body text until the parse ends). If the parse aborts mid-way (parse-timeout, cancellation, OOM), the already-streamed children are durable in the index but the root is never written, so they are orphaned under a root that does not exist. This is exactly the "embedded files indexed but not their root" symptom seen on large OST corpora.

`StreamingSpewCoordinator` now captures the root off the worker as embeds are written, and on `close()` (which runs even when the foreground never reached `spew()`) writes a contentless root stub when embeds were streamed but the real root was not. A later re-run of the stage replaces the stub with the fully-parsed root.

- feat: `Spewer.writeRootStub` (default no-op; index-backed spewers override it — datashare's ElasticsearchSpewer does, in a follow-up)
- fix: coordinator writes the stub on abort only when embeds were actually written and the root was not, skipping duplicate roots
- test: stub written on abort-before-root; not written on normal completion; not written when no embeds were produced

Note: the datashare `ElasticsearchSpewer.writeRootStub` override (the actual index write) ships separately and depends on this via an extract version bump.