### PR TITLE
feat(extract): finalize container root with child count after streaming drain

### DIFF
--- a/extract-lib/src/main/java/org/icij/spewer/Spewer.java
+++ b/extract-lib/src/main/java/org/icij/spewer/Spewer.java
@@ -73,6 +73,22 @@ public abstract class Spewer implements AutoCloseable, Serializable {
         // no-op by default
     }
 
+    /**
+     * Finalize a container ROOT that was fully written on the normal streaming path, once the spew
+     * worker has drained and the child count is final. Lets an index-backed spewer record how many
+     * children were indexed under the root and mark it complete. Called at most once per root, only
+     * when the root was written successfully and had at least one child written (so it is a container).
+     *
+     * <p>Default no-op. Unlike {@link #writeRootStub} (the aborted path), this runs on successful
+     * completion: the root document already exists, so implementations update it rather than create it.
+     *
+     * @param root            the container root already written during the parse
+     * @param writtenChildren the total number of embedded children written under this root
+     */
+    protected void finalizeRoot(final TikaDocument root, final long writtenChildren) throws IOException {
+        // no-op by default
+    }
+
     public void write(final TikaDocument document) throws IOException {
         try {
             writeDocument(document, null, null, 0);

--- a/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
+++ b/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
@@ -105,7 +105,12 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
             // because reading its content drives the parse). If the root was fully written and it is a
             // container (at least one child written), finalize it so the endpoint can record the child
             // count and mark it complete. Best-effort: a finalize failure must not mask the parse result.
-            if (rootWritten && !root.isDuplicate() && writtenEmbeds.get() > 0) {
+            // Skip finalize when the thread was interrupted (parse cancelled): awaitDrained may have
+            // returned early, so writtenEmbeds is not final, and a cancelled container must not be
+            // recorded as a fully-processed one. The aborted-root path (writeRootStubIfOrphaned) covers
+            // orphaned children instead.
+            if (rootWritten && !root.isDuplicate() && writtenEmbeds.get() > 0
+                    && !Thread.currentThread().isInterrupted()) {
                 try {
                     spewer.finalizeRoot(root, writtenEmbeds.get());
                 } catch (final Throwable t) {

--- a/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
+++ b/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
@@ -101,6 +101,17 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
             // resources are still alive while the worker reads them; only then close the root reader.
             awaitDrained();
             shutdownWorker();
+            // The child count is final only now (the root was written before the worker drained,
+            // because reading its content drives the parse). If the root was fully written and it is a
+            // container (at least one child written), finalize it so the endpoint can record the child
+            // count and mark it complete. Best-effort: a finalize failure must not mask the parse result.
+            if (rootWritten && !root.isDuplicate() && writtenEmbeds.get() > 0) {
+                try {
+                    spewer.finalizeRoot(root, writtenEmbeds.get());
+                } catch (final Throwable t) {
+                    logger.error("failed to finalize root {}", root.getId(), t);
+                }
+            }
             Spewer.closeReaderQuietly(root);
         }
         if (rootError != null) {

--- a/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
+++ b/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
@@ -43,6 +43,15 @@ public class StreamingSpewCoordinatorTest {
             rootStubs.add(root.getId());
             rootStubChildCounts.add(writtenChildren);
         }
+
+        final List<String> finalizedRoots = Collections.synchronizedList(new ArrayList<>());
+        final List<Long> finalizeChildCounts = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        protected void finalizeRoot(TikaDocument root, long writtenChildren) {
+            finalizedRoots.add(root.getId());
+            finalizeChildCounts.add(writtenChildren);
+        }
     }
 
     private TikaDocument doc(String id, Reader reader) {
@@ -71,6 +80,42 @@ public class StreamingSpewCoordinatorTest {
         // Root and both embeds written; the two embeds before await completes.
         assertThat(spewer.written).contains("root", "e1", "e2");
         assertThat(spewer.written).hasSize(3);
+    }
+
+    @Test
+    public void testFinalizesRootWithChildCountOnNormalCompletion() throws Exception {
+        RecordingSpewer spewer = new RecordingSpewer();
+        TikaDocument root = doc("root", new StringReader("root-body"));
+        TikaDocument e1 = doc("e1", new StringReader("a"));
+        TikaDocument e2 = doc("e2", new StringReader("b"));
+
+        try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
+            coord.promise();
+            coord.ready(new SpewItem(e1, root, root, 1));
+            coord.promise();
+            coord.ready(new SpewItem(e2, root, root, 1));
+            coord.spew(root);
+        }
+
+        // Root written normally + it is a container (2 children written): finalize once with the count.
+        assertThat(spewer.written).contains("root", "e1", "e2");
+        assertThat(spewer.finalizedRoots).containsOnly("root");
+        assertThat(spewer.finalizeChildCounts).containsOnly(2L);
+        // The normal path never writes a stub.
+        assertThat(spewer.rootStubs).isEmpty();
+    }
+
+    @Test
+    public void testDoesNotFinalizeRootWithoutChildren() throws Exception {
+        RecordingSpewer spewer = new RecordingSpewer();
+        TikaDocument root = doc("root", new StringReader("root-body"));
+
+        try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
+            coord.spew(root); // a plain, childless document is not a container: no finalize
+        }
+
+        assertThat(spewer.written).contains("root");
+        assertThat(spewer.finalizedRoots).isEmpty();
     }
 
     @Test

--- a/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
+++ b/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
@@ -106,6 +106,37 @@ public class StreamingSpewCoordinatorTest {
     }
 
     @Test
+    public void testDoesNotFinalizeRootWhenCancelledMidStream() throws Exception {
+        RecordingSpewer spewer = new RecordingSpewer();
+        TikaDocument root = doc("root", new StringReader("root-body"));
+        TikaDocument e1 = doc("e1", new StringReader("a"));
+
+        try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
+            coord.start();
+            coord.promise();
+            coord.ready(new SpewItem(e1, root, root, 1));
+            // wait until the child is actually written, so writtenEmbeds > 0 and the only thing that
+            // can suppress finalize is the cancellation guard (not the empty-container guard).
+            for (int i = 0; i < 200 && coord.writtenCount() < 1; i++) {
+                Thread.sleep(5);
+            }
+            assertThat(coord.writtenCount()).isEqualTo(1L);
+
+            Thread.currentThread().interrupt(); // the parse thread is cancelled
+            try {
+                coord.spew(root);
+            } finally {
+                Thread.interrupted(); // clear so we don't poison the test-runner thread
+            }
+        }
+
+        // A cancelled parse must not be finalized as a complete container (its count is unreliable and
+        // the container was not fully processed); the child was still written.
+        assertThat(spewer.written).contains("e1");
+        assertThat(spewer.finalizedRoots).isEmpty();
+    }
+
+    @Test
     public void testDoesNotFinalizeRootWithoutChildren() throws Exception {
         RecordingSpewer spewer = new RecordingSpewer();
         TikaDocument root = doc("root", new StringReader("root-body"));


### PR DESCRIPTION
Completes the streaming-spew recovery signalling. On the normal path the container root is written before the spew worker finishes draining (reading the root's content is what drives the parse), so the total child count is not known at root-write time. This adds a post-drain finalize hook so an index-backed spewer can record how many children were indexed under a fully-parsed root and mark it complete — the counterpart to writeRootStub (the aborted path).

- feat: add Spewer.finalizeRoot(root, writtenChildren) (default no-op)
- feat: StreamingSpewCoordinator.spew() calls finalizeRoot after awaitDrained, only when the root was written and it is a container (>=1 child written); best-effort, never masks the parse result
- test: finalize fires once with the child count on normal completion; not fired for a childless document

Follow-up (datashare, after this releases + version bump): override finalizeRoot to update the root with recoveryStatus=COMPLETE and nbChildrenEmitted, giving finished container roots the same partial/complete + child-count signal that aborted roots already get via writeRootStub.