### PR TITLE
feat: show what's left on the heartbeat

### DIFF
--- a/extract-lib/pom.xml
+++ b/extract-lib/pom.xml
@@ -64,6 +64,16 @@
             <version>${tika-version}</version>
         </dependency>
 
+        <!-- Was previously only a transitive dependency (via tika-parser-webarchive-module). Declared
+             directly so extract-lib can use its ZIP/7z catalog APIs without relying on Tika's classpath.
+             No dependencyManagement entry exists for it; pinned to the version already resolved
+             transitively (1.28.0) so this addition does not change what the rest of the build gets. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
+        </dependency>
+
         <!-- Bytecode library used by Tika's ClassParser to parse .class files. Declared directly (rather
              than left transitive through tika-parser-code-module) so extract-lib exports a modern ASM at
              a short dependency path, preventing an older asm from winning mediation downstream. -->

--- a/extract-lib/src/main/java/org/icij/extract/extractor/ArchiveEntryCounter.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/ArchiveEntryCounter.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.OptionalLong;
+import java.util.zip.ZipEntry;
 
 /**
  * Cheaply counts the top-level entries of an archive whose format carries a catalog (ZIP central
@@ -83,7 +84,12 @@ public final class ArchiveEntryCounter {
                 // this central-directory count would otherwise count every internal ZIP part
                 // (dozens), producing a percentage that never reaches 100%. Fall back to the
                 // count-only heartbeat for these.
-                if ("[Content_Types].xml".equals(name) || "mimetype".equals(name)) {
+                // OOXML marks itself with a root "[Content_Types].xml"; ODF/EPUB with a root "mimetype"
+                // entry that the spec requires to be STORED (uncompressed). Requiring STORED for the
+                // mimetype case avoids misclassifying a genuine archive that merely contains a
+                // (typically deflated) file named "mimetype".
+                if ("[Content_Types].xml".equals(name)
+                        || ("mimetype".equals(name) && entry.getMethod() == ZipEntry.STORED)) {
                     isContainerDocument = true;
                 }
                 if (!entry.isDirectory()) {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/ArchiveEntryCounter.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/ArchiveEntryCounter.java
@@ -72,11 +72,26 @@ public final class ArchiveEntryCounter {
         // ZipFile reads only the central directory; no entry data is decompressed.
         try (ZipFile zip = ZipFile.builder().setPath(path).get()) {
             long count = 0;
+            boolean isContainerDocument = false;
             final Enumeration<ZipArchiveEntry> entries = zip.getEntries();
             while (entries.hasMoreElements()) {
-                if (!entries.nextElement().isDirectory()) {
+                final ZipArchiveEntry entry = entries.nextElement();
+                final String name = entry.getName();
+                // OOXML (docx/xlsx/pptx) and ODF/EPUB (odt/ods/odp/epub) are ZIP containers, but
+                // Tika parses them with the dedicated OOXML/ODF parsers, not PackageParser. Those
+                // parsers emit only the real embedded media as depth-1 embeds (a handful), while
+                // this central-directory count would otherwise count every internal ZIP part
+                // (dozens), producing a percentage that never reaches 100%. Fall back to the
+                // count-only heartbeat for these.
+                if ("[Content_Types].xml".equals(name) || "mimetype".equals(name)) {
+                    isContainerDocument = true;
+                }
+                if (!entry.isDirectory()) {
                     count++;
                 }
+            }
+            if (isContainerDocument) {
+                return OptionalLong.empty();
             }
             return OptionalLong.of(count);
         }

--- a/extract-lib/src/main/java/org/icij/extract/extractor/ArchiveEntryCounter.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/ArchiveEntryCounter.java
@@ -1,0 +1,96 @@
+package org.icij.extract.extractor;
+
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
+import org.apache.commons.compress.archivers.sevenz.SevenZFile;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.OptionalLong;
+
+/**
+ * Cheaply counts the top-level entries of an archive whose format carries a catalog (ZIP central
+ * directory, 7z header), without decompressing content. Used to give the progress heartbeat a
+ * denominator. Any failure (unknown/unsupported format, corrupt or encrypted archive, no readable
+ * file) yields {@link OptionalLong#empty()} so extraction proceeds with the count-only heartbeat.
+ * Directory entries are excluded so the count matches the embeds Tika's PackageParser emits.
+ */
+public final class ArchiveEntryCounter {
+    private static final Logger logger = LoggerFactory.getLogger(ArchiveEntryCounter.class);
+
+    private ArchiveEntryCounter() {}
+
+    public static OptionalLong countTopLevelEntries(final Path path) {
+        try {
+            final byte[] magic = readMagic(path, 6);
+            if (isZip(magic)) {
+                return countZip(path);
+            }
+            if (isSevenZ(magic)) {
+                return countSevenZ(path);
+            }
+            return OptionalLong.empty();
+        } catch (final Throwable t) {
+            // Never let a pre-count failure affect extraction.
+            logger.debug("archive pre-count skipped for {}: {}", path, t.toString());
+            return OptionalLong.empty();
+        }
+    }
+
+    private static byte[] readMagic(final Path path, final int n) throws IOException {
+        final byte[] buf = new byte[n];
+        try (InputStream in = Files.newInputStream(path)) {
+            int off = 0, r;
+            while (off < n && (r = in.read(buf, off, n - off)) != -1) {
+                off += r;
+            }
+        }
+        return buf;
+    }
+
+    // Local file header "PK\x03\x04", empty archive "PK\x05\x06", spanned "PK\x07\x08".
+    private static boolean isZip(final byte[] m) {
+        return m.length >= 4 && m[0] == 'P' && m[1] == 'K'
+                && (m[2] == 3 || m[2] == 5 || m[2] == 7)
+                && (m[3] == 4 || m[3] == 6 || m[3] == 8);
+    }
+
+    // 7z signature: 37 7A BC AF 27 1C
+    private static boolean isSevenZ(final byte[] m) {
+        return m.length >= 6 && (m[0] & 0xFF) == 0x37 && (m[1] & 0xFF) == 0x7A
+                && (m[2] & 0xFF) == 0xBC && (m[3] & 0xFF) == 0xAF
+                && (m[4] & 0xFF) == 0x27 && (m[5] & 0xFF) == 0x1C;
+    }
+
+    private static OptionalLong countZip(final Path path) throws IOException {
+        // ZipFile reads only the central directory; no entry data is decompressed.
+        try (ZipFile zip = ZipFile.builder().setPath(path).get()) {
+            long count = 0;
+            final Enumeration<ZipArchiveEntry> entries = zip.getEntries();
+            while (entries.hasMoreElements()) {
+                if (!entries.nextElement().isDirectory()) {
+                    count++;
+                }
+            }
+            return OptionalLong.of(count);
+        }
+    }
+
+    private static OptionalLong countSevenZ(final Path path) throws IOException {
+        try (SevenZFile sevenZ = SevenZFile.builder().setPath(path).get()) {
+            long count = 0;
+            for (final SevenZArchiveEntry e : sevenZ.getEntries()) {
+                if (!e.isDirectory()) {
+                    count++;
+                }
+            }
+            return OptionalLong.of(count);
+        }
+    }
+}

--- a/extract-lib/src/main/java/org/icij/extract/extractor/ArchiveEntryCounter.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/ArchiveEntryCounter.java
@@ -1,5 +1,6 @@
 package org.icij.extract.extractor;
 
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZFile;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
@@ -7,6 +8,7 @@ import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -29,11 +31,14 @@ public final class ArchiveEntryCounter {
 
     public static OptionalLong countTopLevelEntries(final Path path) {
         try {
-            final byte[] magic = readMagic(path, 6);
-            if (isZip(magic)) {
+            final String type;
+            try (InputStream in = new BufferedInputStream(Files.newInputStream(path))) {
+                type = ArchiveStreamFactory.detect(in);
+            }
+            if (ArchiveStreamFactory.ZIP.equals(type)) {
                 return countZip(path);
             }
-            if (isSevenZ(magic)) {
+            if (ArchiveStreamFactory.SEVEN_Z.equals(type)) {
                 return countSevenZ(path);
             }
             return OptionalLong.empty();
@@ -42,31 +47,6 @@ public final class ArchiveEntryCounter {
             logger.debug("archive pre-count skipped for {}: {}", path, t.toString());
             return OptionalLong.empty();
         }
-    }
-
-    private static byte[] readMagic(final Path path, final int n) throws IOException {
-        final byte[] buf = new byte[n];
-        try (InputStream in = Files.newInputStream(path)) {
-            int off = 0, r;
-            while (off < n && (r = in.read(buf, off, n - off)) != -1) {
-                off += r;
-            }
-        }
-        return buf;
-    }
-
-    // Local file header "PK\x03\x04", empty archive "PK\x05\x06", spanned "PK\x07\x08".
-    private static boolean isZip(final byte[] m) {
-        return m.length >= 4 && m[0] == 'P' && m[1] == 'K'
-                && (m[2] == 3 || m[2] == 5 || m[2] == 7)
-                && (m[3] == 4 || m[3] == 6 || m[3] == 8);
-    }
-
-    // 7z signature: 37 7A BC AF 27 1C
-    private static boolean isSevenZ(final byte[] m) {
-        return m.length >= 6 && (m[0] & 0xFF) == 0x37 && (m[1] & 0xFF) == 0x7A
-                && (m[2] & 0xFF) == 0xBC && (m[3] & 0xFF) == 0xAF
-                && (m[4] & 0xFF) == 0x27 && (m[5] & 0xFF) == 0x1C;
     }
 
     private static OptionalLong countZip(final Path path) throws IOException {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -321,6 +321,17 @@ public class EmbedSpawner extends EmbedParser {
 						skipped.get(TikaCoreProperties.RESOURCE_NAME_KEY), root));
 	}
 
+	// A top-level (depth-1) archive entry is the countable "unit" for the completion estimate. It is
+	// counted on BOTH the normal spawn path and the size-skip path: ArchiveEntryCounter's denominator
+	// included the entry, so a size-refused top-level entry must still advance the numerator or the
+	// percentage can never reach 100%. Skipped when a parser (PST) supplies its own numerator.
+	private void countTopLevelUnit() {
+		if (progress != null && !progress.parserTracksUnits()
+				&& baseDepthOffset + tikaDocumentStack.size() == 1) {
+			progress.incrementUnits();
+		}
+	}
+
 	private void recordSkippedAtSize(final Metadata skipped) {
 		recordSkip(EMBEDS_SKIPPED_MAX_SIZE,
 				() -> progress.incrementEmbedsSkippedMaxSize(),
@@ -379,17 +390,13 @@ public class EmbedSpawner extends EmbedParser {
 			// containers that don't report a length are never broken.
 			if (exceedsMaxEmbedSize(metadata, maxEmbedSizeBytes)) {
 				recordSkippedAtSize(metadata);
+				countTopLevelUnit(); // size-refused top-level entry is still in the archive denominator
 				return;
 			}
 			if (progress != null) {
 				progress.incrementEmbeds();
-				// A top-level archive entry is a depth-1 embed; it is the countable "unit" for the
-				// completion estimate. Skip when a parser (PST) supplies its own unit numerator.
-				final int embedDepth = baseDepthOffset + tikaDocumentStack.size();
-				if (embedDepth == 1 && !progress.parserTracksUnits()) {
-					progress.incrementUnits();
-				}
 			}
+			countTopLevelUnit();
 			// we must not close the input with (try(TikaInputStream.get(input){...}) because
 			// it closes the stream and stops tika to get next entries in the PackageParser.
 			// Wrap once and reuse for whichever path runs: shouldTranslate() inspects the stream's

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -145,6 +145,16 @@ public class EmbedSpawner extends EmbedParser {
 				() -> null, false, null, null, false, 0L, null, null, false, maxEmbedDepth, maxEmbedSizeBytes);
 	}
 
+	// Serial spawner with an explicit depth limit AND a live progress tracker (test-friendly). Mirrors
+	// the no-progress serial+depth constructor above (no fan-out, no OCR, no spool), substituting the
+	// passed `progress` for the `null` progress argument in that delegation.
+	EmbedSpawner(final TikaDocument root, final ExtractionProgress progress, final int maxEmbedDepth) {
+		this(root, new ParseContext(), null, w -> new BodyContentHandler(w),
+				64L * 1024 * 1024, new TemporaryResources(), () -> false,
+				() -> null, false, progress, null, false, 0L, null, null, false, maxEmbedDepth,
+				DEFAULT_MAX_EMBED_SIZE_BYTES);
+	}
+
 	EmbedSpawner(final TikaDocument root, final ParseContext context, final Path outputPath,
 				 final Function<Writer, ContentHandler> handlerFunction,
 				 final long embedMemoryBudgetBytes, final TemporaryResources tmp,
@@ -373,6 +383,12 @@ public class EmbedSpawner extends EmbedParser {
 			}
 			if (progress != null) {
 				progress.incrementEmbeds();
+				// A top-level archive entry is a depth-1 embed; it is the countable "unit" for the
+				// completion estimate. Skip when a parser (PST) supplies its own unit numerator.
+				final int embedDepth = baseDepthOffset + tikaDocumentStack.size();
+				if (embedDepth == 1 && !progress.parserTracksUnits()) {
+					progress.incrementUnits();
+				}
 			}
 			// we must not close the input with (try(TikaInputStream.get(input){...}) because
 			// it closes the stream and stops tika to get next entries in the PackageParser.

--- a/extract-lib/src/main/java/org/icij/extract/extractor/ExtractionProgress.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/ExtractionProgress.java
@@ -12,6 +12,9 @@ public class ExtractionProgress {
     private final AtomicLong ocrCompleted = new AtomicLong();
     private final AtomicLong embedsSkippedMaxDepth = new AtomicLong();
     private final AtomicLong embedsSkippedMaxSize = new AtomicLong();
+    private final AtomicLong expectedUnits = new AtomicLong(-1L);
+    private final AtomicLong unitsParsed = new AtomicLong();
+    private volatile boolean parserTracksUnits = false;
 
     public ExtractionProgress(final Path path, final long startMillis) {
         this.path = path;
@@ -30,5 +33,14 @@ public class ExtractionProgress {
     public void incrementOcrCompleted() { ocrCompleted.incrementAndGet(); }
     public void incrementEmbedsSkippedMaxDepth() { embedsSkippedMaxDepth.incrementAndGet(); }
     public void incrementEmbedsSkippedMaxSize() { embedsSkippedMaxSize.incrementAndGet(); }
+    /** A "unit" is the container's cheaply-countable top-level element (a PST message or an
+     * archive entry). Used only to project a completion percentage; -1 means unknown. */
+    public boolean setExpectedUnits(final long total) { return expectedUnits.compareAndSet(-1L, total); }
+    public long expectedUnits() { return expectedUnits.get(); }
+    public void incrementUnits() { unitsParsed.incrementAndGet(); }
+    public long unitsParsed() { return unitsParsed.get(); }
+    /** Marked by a parser that supplies its own unit numerator (PST), so EmbedSpawner does not also count. */
+    public void markParserTracksUnits() { parserTracksUnits = true; }
+    public boolean parserTracksUnits() { return parserTracksUnits; }
     public long elapsedMillis(final long now) { return now - startMillis; }
 }

--- a/extract-lib/src/main/java/org/icij/extract/extractor/ExtractionProgress.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/ExtractionProgress.java
@@ -39,6 +39,14 @@ public class ExtractionProgress {
     public long expectedUnits() { return expectedUnits.get(); }
     public void incrementUnits() { unitsParsed.incrementAndGet(); }
     public long unitsParsed() { return unitsParsed.get(); }
+    /** Snap the numerator to the known total, so a container whose parse has completed reads 100%
+     * even when some sub-units were skipped, failed, or filtered. No-op when the total is unknown. */
+    public void completeUnits() {
+        final long total = expectedUnits.get();
+        if (total >= 0) {
+            unitsParsed.set(total);
+        }
+    }
     /** Marked by a parser that supplies its own unit numerator (PST), so EmbedSpawner does not also count. */
     public void markParserTracksUnits() { parserTracksUnits = true; }
     public boolean parserTracksUnits() { return parserTracksUnits; }

--- a/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/Extractor.java
@@ -964,6 +964,12 @@ public class Extractor implements AutoCloseable {
             embedTextResources = new TemporaryResources();
             // Live progress for this path (null when called outside doExtract, e.g. page extraction).
             final ExtractionProgress currentProgress = progressTracker.get(path);
+            if (currentProgress != null) {
+                // PST parser reads this back from the context to publish its message total/numerator.
+                context.set(ExtractionProgress.class, currentProgress);
+                // Archives (ZIP/7z) get their total here; EmbedSpawner supplies their numerator.
+                applyArchiveUnitCount(path, currentProgress);
+            }
             // Class name of the configured OCR parser, set SYNCHRONOUSLY on the shared embed metadata
             // by the deferred-OCR path so the indexed OCR_PARSER matches what serial mode produces
             // (OCRParserAdapter sets OCR_PARSER to its delegate parser's class name, i.e. the
@@ -1006,6 +1012,13 @@ public class Extractor implements AutoCloseable {
             }
             throw e;
         }
+    }
+
+    // Best-effort: give the progress heartbeat a denominator for catalog archives (ZIP/7z). Any
+    // failure leaves expectedUnits unknown (-1) and the heartbeat stays count-only. Package-private
+    // for direct testing.
+    void applyArchiveUnitCount(final Path path, final ExtractionProgress progress) {
+        ArchiveEntryCounter.countTopLevelEntries(path).ifPresent(progress::setExpectedUnits);
     }
 
     private void excludeParser(final Class<? extends Parser> exclude) {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/LoggingProgressListener.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/LoggingProgressListener.java
@@ -16,9 +16,25 @@ public class LoggingProgressListener implements ProgressListener {
 
     static String formatLine(final ExtractionProgress p, final long now) {
         final long seconds = p.elapsedMillis(now) / 1000L;
-        return String.format("%s: %ds, %d embeds, %d/%d OCR done, %d skipped(maxDepth), %d skipped(maxSize)",
-                p.path(), seconds, p.embedsParsed(), p.ocrCompleted(), p.ocrSubmitted(),
+        return String.format("%s: %ds, %s, %d/%d OCR done, %d skipped(maxDepth), %d skipped(maxSize)",
+                p.path(), seconds, embedSegment(p), p.ocrCompleted(), p.ocrSubmitted(),
                 p.embedsSkippedMaxDepth(), p.embedsSkippedMaxSize());
+    }
+
+    // Embed count with a projected total + percentage when the container exposes a cheap unit total
+    // (PST messages, archive entries); otherwise the plain running count. The total is a projection
+    // (embeds scale by the observed embeds-per-unit ratio), hence the '~'; the percentage is the real
+    // unitsParsed/expectedUnits ground truth and never exceeds 100%.
+    private static String embedSegment(final ExtractionProgress p) {
+        final long embeds = p.embedsParsed();
+        final long expectedUnits = p.expectedUnits();
+        final long unitsParsed = p.unitsParsed();
+        if (expectedUnits <= 0 || unitsParsed <= 0) {
+            return String.format("%d embeds", embeds);
+        }
+        final long estTotal = Math.max(embeds, Math.round((double) embeds * expectedUnits / unitsParsed));
+        final long pct = Math.min(100L, unitsParsed * 100L / expectedUnits);
+        return String.format("%d/~%d embeds (~%d%%)", embeds, estTotal, pct);
     }
 
     @Override

--- a/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
+++ b/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
@@ -163,8 +163,9 @@ public class ResilientOutlookPSTParser implements Parser {
         // measurable PST wins ownership; a nested PST-in-PST loses and never tracks units. On win we
         // mark parserTracksUnits (so EmbedSpawner does not also count) and point THIS parse's
         // Reconciliation at the progress, so every emitted message increments the numerator.
-        if (progress != null && messageDescriptorIds != null
-                && progress.setExpectedUnits(messageDescriptorIds.size())) {
+        final boolean ownsUnits = progress != null && messageDescriptorIds != null
+                && progress.setExpectedUnits(messageDescriptorIds.size());
+        if (ownsUnits) {
             progress.markParserTracksUnits();
             reconciliation.trackUnits(progress);
         }
@@ -195,6 +196,15 @@ public class ResilientOutlookPSTParser implements Parser {
             recordReconciliation(metadata, pstPath, messageDescriptorIds, emission.emittedCount());
             recordAttachmentIntegrity(metadata, pstPath, emission);
         });
+
+        // The parse of this container is complete; snap the numerator to 100%. During the walk the
+        // numerator tracked emitted messages (live progress); some enumerated descriptors may have
+        // failed to emit or been recovered, so force the final reading to a clean 100% rather than
+        // leaving it stuck just below. Only the owning top-level parse does this (nested PSTs lost the
+        // set-once CAS above, so ownsUnits is false for them).
+        if (ownsUnits) {
+            progress.completeUnits();
+        }
     }
 
     // One task per folder. Each task opens its OWN PSTFile handle (libpst is not thread-safe),

--- a/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
+++ b/extract-lib/src/main/java/org/icij/extract/parser/ResilientOutlookPSTParser.java
@@ -119,6 +119,8 @@ public class ResilientOutlookPSTParser implements Parser {
         final Reconciliation reconciliation = new Reconciliation();
         final EmissionContext emission = new EmissionContext(xhtml, extractor, reconciliation);
         final PstFanoutConfig fanout = context.get(PstFanoutConfig.class);
+        final org.icij.extract.extractor.ExtractionProgress progress =
+                context.get(org.icij.extract.extractor.ExtractionProgress.class);
 
         xhtml.startDocument();
         final String pstPath = TikaInputStream.get(stream).getFile().getPath();
@@ -128,7 +130,7 @@ public class ResilientOutlookPSTParser implements Parser {
         PSTFile pstFile = null;
         try {
             pstFile = new PSTFile(pstPath);
-            extractAllMessages(pstFile, pstPath, emission, metadata, reconciliation, fanout);
+            extractAllMessages(pstFile, pstPath, emission, metadata, reconciliation, fanout, progress);
         } catch (final TikaException e) {
             throw e;
         } catch (final Exception e) {
@@ -147,7 +149,8 @@ public class ResilientOutlookPSTParser implements Parser {
     private void extractAllMessages(final PSTFile pstFile, final String pstPath,
                                     final EmissionContext emission, final Metadata metadata,
                                     final Reconciliation reconciliation,
-                                    final PstFanoutConfig fanout) throws Exception {
+                                    final PstFanoutConfig fanout,
+                                    final org.icij.extract.extractor.ExtractionProgress progress) throws Exception {
         // java-libpst reads single-block data from OST 2013 (type-36) files correctly, but
         // truncates or fails on attachment data spanning multiple blocks. We can't repair the
         // bytes, so flag the affected attachments to make the loss visible. Confined to type-36
@@ -156,6 +159,15 @@ public class ResilientOutlookPSTParser implements Parser {
             emission.enableAttachmentIntegrityCheck();
         }
         final List<Integer> messageDescriptorIds = enumerateMessageDescriptorIds(pstFile, pstPath);
+        // Publish the message total for the progress estimate. Set-once (CAS): only the top-level,
+        // measurable PST wins ownership; a nested PST-in-PST loses and never tracks units. On win we
+        // mark parserTracksUnits (so EmbedSpawner does not also count) and point THIS parse's
+        // Reconciliation at the progress, so every emitted message increments the numerator.
+        if (progress != null && messageDescriptorIds != null
+                && progress.setExpectedUnits(messageDescriptorIds.size())) {
+            progress.markParserTracksUnits();
+            reconciliation.trackUnits(progress);
+        }
         final boolean fanoutRequested = fanout != null && fanout.enabled()
                 && emission.extractor instanceof EmbedSpawner;
         final Map<Integer, String> folderPaths =
@@ -759,10 +771,19 @@ public class ResilientOutlookPSTParser implements Parser {
         private final AtomicInteger unrecoveredAttachments = new AtomicInteger();
         private final AtomicInteger encryptedAttachments = new AtomicInteger();
 
+        private volatile org.icij.extract.extractor.ExtractionProgress unitProgress;
+
         boolean markEmitted(final long id) { return emittedDescriptorIds.add(id); }
         void unmarkEmitted(final long id) { emittedDescriptorIds.remove(id); }
         boolean alreadyEmitted(final long id) { return emittedDescriptorIds.contains(id); }
-        void incrementEmitted() { emittedCount.incrementAndGet(); }
+        void trackUnits(final org.icij.extract.extractor.ExtractionProgress p) { this.unitProgress = p; }
+        void incrementEmitted() {
+            emittedCount.incrementAndGet();
+            final org.icij.extract.extractor.ExtractionProgress p = unitProgress;
+            if (p != null) {
+                p.incrementUnits();
+            }
+        }
         int emittedCount() { return emittedCount.get(); }
         void enableAttachmentIntegrityCheck() { checkAttachmentIntegrity = true; }
         boolean shouldCheckAttachmentIntegrity() { return checkAttachmentIntegrity; }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ArchiveEntryCounterTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ArchiveEntryCounterTest.java
@@ -1,0 +1,65 @@
+package org.icij.extract.extractor;
+
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
+import org.apache.commons.compress.archivers.sevenz.SevenZOutputFile;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.OptionalLong;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ArchiveEntryCounterTest {
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+    private Path zipWith(int files) throws Exception {
+        Path zip = tmp.newFile("a.zip").toPath();
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip))) {
+            zos.putNextEntry(new ZipEntry("dir/"));        // directory entry: must NOT be counted
+            zos.closeEntry();
+            for (int i = 0; i < files; i++) {
+                zos.putNextEntry(new ZipEntry("dir/f" + i + ".txt"));
+                zos.write(("hello" + i).getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+        }
+        return zip;
+    }
+
+    @Test public void testCountsZipNonDirectoryEntries() throws Exception {
+        assertThat(ArchiveEntryCounter.countTopLevelEntries(zipWith(3)).getAsLong()).isEqualTo(3L);
+    }
+
+    @Test public void testCounts7zNonDirectoryEntries() throws Exception {
+        Path sevenZ = tmp.newFile("a.7z").toPath();
+        try (SevenZOutputFile out = new SevenZOutputFile(sevenZ.toFile())) {
+            for (int i = 0; i < 2; i++) {
+                Path src = tmp.newFile("s" + i + ".txt").toPath();
+                Files.write(src, ("x" + i).getBytes(StandardCharsets.UTF_8));
+                SevenZArchiveEntry e = out.createArchiveEntry(src.toFile(), "s" + i + ".txt");
+                out.putArchiveEntry(e);
+                out.write(Files.readAllBytes(src));
+                out.closeArchiveEntry();
+            }
+        }
+        assertThat(ArchiveEntryCounter.countTopLevelEntries(sevenZ).getAsLong()).isEqualTo(2L);
+    }
+
+    @Test public void testEmptyForNonArchive() throws Exception {
+        Path txt = tmp.newFile("plain.txt").toPath();
+        Files.write(txt, "not an archive".getBytes(StandardCharsets.UTF_8));
+        assertThat(ArchiveEntryCounter.countTopLevelEntries(txt).isPresent()).isFalse();
+    }
+
+    @Test public void testEmptyForCorruptZipMagic() throws Exception {
+        Path fake = tmp.newFile("fake.zip").toPath();
+        Files.write(fake, new byte[] {'P','K',3,4, 0,0,0,0}); // ZIP magic but truncated/garbage
+        assertThat(ArchiveEntryCounter.countTopLevelEntries(fake).isPresent()).isFalse();
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ArchiveEntryCounterTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ArchiveEntryCounterTest.java
@@ -2,6 +2,8 @@ package org.icij.extract.extractor;
 
 import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZOutputFile;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -128,6 +130,24 @@ public class ArchiveEntryCounterTest {
         OptionalLong result = ArchiveEntryCounter.countTopLevelEntries(zip);
         assertThat(result.isPresent()).isTrue();
         assertThat(result.getAsLong()).isEqualTo(3L);
+    }
+
+    @Test public void testEmptyForDetectedButUnsupportedFormat() throws Exception {
+        // TAR carries no catalog we can read cheaply (no central directory / header index), so a
+        // detected-but-unsupported format must fall back to the count-only heartbeat rather than
+        // being counted or crashing.
+        Path tar = tmp.newFile("a.tar").toPath();
+        try (TarArchiveOutputStream taos = new TarArchiveOutputStream(Files.newOutputStream(tar))) {
+            for (int i = 0; i < 2; i++) {
+                byte[] content = ("hello" + i).getBytes(StandardCharsets.UTF_8);
+                TarArchiveEntry entry = new TarArchiveEntry("f" + i + ".txt");
+                entry.setSize(content.length);
+                taos.putArchiveEntry(entry);
+                taos.write(content);
+                taos.closeArchiveEntry();
+            }
+        }
+        assertThat(ArchiveEntryCounter.countTopLevelEntries(tar).isPresent()).isFalse();
     }
 
     private static long crc32(final byte[] data) {

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ArchiveEntryCounterTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ArchiveEntryCounterTest.java
@@ -84,11 +84,18 @@ public class ArchiveEntryCounterTest {
 
     @Test public void testEmptyForOdfOrEpubZipContainer() throws Exception {
         // ODF (odt/ods/odp) and EPUB documents are also ZIP containers with a dedicated,
-        // non-PackageParser Tika parser, signalled by a "mimetype" entry.
+        // non-PackageParser Tika parser, signalled by a root "mimetype" entry that the EPUB/ODF
+        // spec requires to be STORED (uncompressed).
         Path epub = tmp.newFile("fake.epub").toPath();
         try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(epub))) {
-            zos.putNextEntry(new ZipEntry("mimetype"));
-            zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
+            ZipEntry mimetype = new ZipEntry("mimetype");
+            byte[] mimetypeBytes = "application/epub+zip".getBytes(StandardCharsets.UTF_8);
+            mimetype.setMethod(ZipEntry.STORED);
+            mimetype.setSize(mimetypeBytes.length);
+            mimetype.setCompressedSize(mimetypeBytes.length);
+            mimetype.setCrc(crc32(mimetypeBytes));
+            zos.putNextEntry(mimetype);
+            zos.write(mimetypeBytes);
             zos.closeEntry();
             zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
             zos.write("<container/>".getBytes(StandardCharsets.UTF_8));
@@ -98,5 +105,34 @@ public class ArchiveEntryCounterTest {
             zos.closeEntry();
         }
         assertThat(ArchiveEntryCounter.countTopLevelEntries(epub).isPresent()).isFalse();
+    }
+
+    @Test public void testCountsZipWithDeflatedRootFileNamedMimetype() throws Exception {
+        // A genuine archive can happen to contain a root file literally named "mimetype" that is
+        // (as is typical) DEFLATED, not STORED. That must NOT be misclassified as an EPUB/ODF
+        // container: it should still be counted normally. This is the regression the fix closes.
+        Path zip = tmp.newFile("genuine.zip").toPath();
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip))) {
+            ZipEntry mimetype = new ZipEntry("mimetype");
+            mimetype.setMethod(ZipEntry.DEFLATED);
+            zos.putNextEntry(mimetype);
+            zos.write("just a coincidentally named file".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("readme.txt"));
+            zos.write("hello".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("data.bin"));
+            zos.write(new byte[] {1, 2, 3});
+            zos.closeEntry();
+        }
+        OptionalLong result = ArchiveEntryCounter.countTopLevelEntries(zip);
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.getAsLong()).isEqualTo(3L);
+    }
+
+    private static long crc32(final byte[] data) {
+        java.util.zip.CRC32 crc = new java.util.zip.CRC32();
+        crc.update(data);
+        return crc.getValue();
     }
 }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ArchiveEntryCounterTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ArchiveEntryCounterTest.java
@@ -62,4 +62,41 @@ public class ArchiveEntryCounterTest {
         Files.write(fake, new byte[] {'P','K',3,4, 0,0,0,0}); // ZIP magic but truncated/garbage
         assertThat(ArchiveEntryCounter.countTopLevelEntries(fake).isPresent()).isFalse();
     }
+
+    @Test public void testEmptyForOoxmlZipContainer() throws Exception {
+        // OOXML documents (docx/xlsx/pptx) are ZIP containers parsed by Tika's OOXML parser, not
+        // PackageParser: only the real embedded media becomes depth-1 embeds, so the central
+        // directory count (which includes every internal part) must not be used as the estimate.
+        Path docx = tmp.newFile("fake.docx").toPath();
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(docx))) {
+            zos.putNextEntry(new ZipEntry("[Content_Types].xml"));
+            zos.write("<Types/>".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("word/document.xml"));
+            zos.write("<document/>".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("word/media/image1.png"));
+            zos.write(new byte[] {1, 2, 3});
+            zos.closeEntry();
+        }
+        assertThat(ArchiveEntryCounter.countTopLevelEntries(docx).isPresent()).isFalse();
+    }
+
+    @Test public void testEmptyForOdfOrEpubZipContainer() throws Exception {
+        // ODF (odt/ods/odp) and EPUB documents are also ZIP containers with a dedicated,
+        // non-PackageParser Tika parser, signalled by a "mimetype" entry.
+        Path epub = tmp.newFile("fake.epub").toPath();
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(epub))) {
+            zos.putNextEntry(new ZipEntry("mimetype"));
+            zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
+            zos.write("<container/>".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("content.opf"));
+            zos.write("<package/>".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        assertThat(ArchiveEntryCounter.countTopLevelEntries(epub).isPresent()).isFalse();
+    }
 }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerUnitCountTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerUnitCountTest.java
@@ -1,7 +1,9 @@
 package org.icij.extract.extractor;
 
+import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.BodyContentHandler;
 import org.icij.extract.document.DigestIdentifier;
 import org.icij.extract.document.DocumentFactory;
@@ -29,6 +31,23 @@ public class EmbedSpawnerUnitCountTest {
         return m;
     }
 
+    private Metadata nonInline(final String name, final long contentLength) {
+        final Metadata m = nonInline(name);
+        m.set(Metadata.CONTENT_LENGTH, Long.toString(contentLength));
+        return m;
+    }
+
+    // Serial spawner with the depth guard disabled, a live progress tracker, and an explicit
+    // decompressed-size cap, so a depth-1 entry can be refused by the size guard under test.
+    private EmbedSpawner spawnerWithSizeAndProgress(final TikaDocument root, final ExtractionProgress progress,
+                                                     final long maxEmbedSizeBytes) {
+        return new EmbedSpawner(root, new ParseContext(), null,
+                w -> new BodyContentHandler(w),
+                64L * 1024 * 1024, new TemporaryResources(), () -> false,
+                () -> null, false, progress, null, false, 0L, null, null, false, 0,
+                maxEmbedSizeBytes);
+    }
+
     @Test public void testDepthOneEmbedIncrementsUnits() throws Exception {
         final ExtractionProgress progress = new ExtractionProgress(Paths.get("/big.zip"), 0L);
         final TikaDocument root = root("/big.zip");
@@ -51,5 +70,21 @@ public class EmbedSpawnerUnitCountTest {
                 new BodyContentHandler(), nonInline("message1.eml"), false);
 
         assertThat(progress.unitsParsed()).isEqualTo(0L); // EmbedSpawner must not count when parser owns
+    }
+
+    @Test public void testSizeSkippedDepthOneEntryStillIncrementsUnits() throws Exception {
+        final ExtractionProgress progress = new ExtractionProgress(Paths.get("/big.zip"), 0L);
+        final TikaDocument root = root("/big.zip");
+        // Stack holds only the root -> the next embed is at depth 1; the 100-byte cap refuses it.
+        final EmbedSpawner spawner = spawnerWithSizeAndProgress(root, progress, 100L);
+
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("bomb.bin", 1000L), false);
+
+        // ArchiveEntryCounter's denominator included this top-level entry, so the size-refused
+        // entry must still advance the numerator, or the percentage can never reach 100%.
+        assertThat(progress.unitsParsed()).isEqualTo(1L);
+        // ...but it was never actually parsed.
+        assertThat(progress.embedsParsed()).isEqualTo(0L);
     }
 }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerUnitCountTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerUnitCountTest.java
@@ -1,0 +1,55 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.sax.BodyContentHandler;
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.TikaDocument;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class EmbedSpawnerUnitCountTest {
+
+    private TikaDocument root(final String path) {
+        return new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", Charset.defaultCharset()))
+                .create(Paths.get(path));
+    }
+
+    private Metadata nonInline(final String name) {
+        final Metadata m = new Metadata();
+        m.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+        return m;
+    }
+
+    @Test public void testDepthOneEmbedIncrementsUnits() throws Exception {
+        final ExtractionProgress progress = new ExtractionProgress(Paths.get("/big.zip"), 0L);
+        final TikaDocument root = root("/big.zip");
+        // Stack holds only the root -> the next embed is at depth 1.
+        final EmbedSpawner spawner = new EmbedSpawner(root, progress, 0);
+
+        spawner.parseEmbedded(new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("entry1.txt"), false);
+
+        assertThat(progress.unitsParsed()).isEqualTo(1L);
+    }
+
+    @Test public void testParserTrackedProgressIsNotDoubleCounted() throws Exception {
+        final ExtractionProgress progress = new ExtractionProgress(Paths.get("/foo.ost"), 0L);
+        progress.markParserTracksUnits(); // PST owns the numerator
+        final TikaDocument root = root("/foo.ost");
+        final EmbedSpawner spawner = new EmbedSpawner(root, progress, 0);
+
+        spawner.parseEmbedded(new ByteArrayInputStream("msg".getBytes(StandardCharsets.UTF_8)),
+                new BodyContentHandler(), nonInline("message1.eml"), false);
+
+        assertThat(progress.unitsParsed()).isEqualTo(0L); // EmbedSpawner must not count when parser owns
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractionProgressTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractionProgressTest.java
@@ -30,4 +30,28 @@ public class ExtractionProgressTest {
         p.incrementEmbedsSkippedMaxDepth();
         assertThat(p.embedsSkippedMaxDepth()).isEqualTo(2L);
     }
+
+    @Test public void testExpectedUnitsDefaultsToUnknown() {
+        ExtractionProgress p = new ExtractionProgress(java.nio.file.Paths.get("/x.ost"), 0L);
+        assertThat(p.expectedUnits()).isEqualTo(-1L);
+        assertThat(p.unitsParsed()).isEqualTo(0L);
+        assertThat(p.parserTracksUnits()).isFalse();
+    }
+
+    @Test public void testSetExpectedUnitsIsSetOnce() {
+        ExtractionProgress p = new ExtractionProgress(java.nio.file.Paths.get("/x.ost"), 0L);
+        assertThat(p.setExpectedUnits(250_000L)).isTrue();
+        assertThat(p.expectedUnits()).isEqualTo(250_000L);
+        // A second call (e.g. a nested container) must not clobber the root total.
+        assertThat(p.setExpectedUnits(7L)).isFalse();
+        assertThat(p.expectedUnits()).isEqualTo(250_000L);
+    }
+
+    @Test public void testIncrementUnitsAndFlag() {
+        ExtractionProgress p = new ExtractionProgress(java.nio.file.Paths.get("/x.ost"), 0L);
+        p.incrementUnits(); p.incrementUnits();
+        assertThat(p.unitsParsed()).isEqualTo(2L);
+        p.markParserTracksUnits();
+        assertThat(p.parserTracksUnits()).isTrue();
+    }
 }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractionProgressTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractionProgressTest.java
@@ -54,4 +54,20 @@ public class ExtractionProgressTest {
         p.markParserTracksUnits();
         assertThat(p.parserTracksUnits()).isTrue();
     }
+
+    @Test public void testCompleteUnitsSnapsToTotal() {
+        ExtractionProgress p = new ExtractionProgress(java.nio.file.Paths.get("/x.ost"), 0L);
+        p.setExpectedUnits(10L);
+        p.incrementUnits(); p.incrementUnits(); p.incrementUnits();
+        p.completeUnits();
+        assertThat(p.unitsParsed()).isEqualTo(10L);
+    }
+
+    @Test public void testCompleteUnitsNoOpWhenUnknown() {
+        ExtractionProgress p = new ExtractionProgress(java.nio.file.Paths.get("/x.ost"), 0L);
+        p.incrementUnits(); p.incrementUnits();
+        p.completeUnits();
+        assertThat(p.unitsParsed()).isEqualTo(2L);
+        assertThat(p.expectedUnits()).isEqualTo(-1L);
+    }
 }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorArchiveUnitsTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorArchiveUnitsTest.java
@@ -36,4 +36,22 @@ public class ExtractorArchiveUnitsTest {
         new Extractor().applyArchiveUnitCount(txt, progress);
         assertThat(progress.expectedUnits()).isEqualTo(-1L);
     }
+
+    @Test public void testApplyArchiveUnitCountLeavesOoxmlContainerUnknown() throws Exception {
+        // docx/xlsx/pptx are ZIP containers parsed by Tika's OOXML parser, not PackageParser, so
+        // the internal ZIP parts are not depth-1 embeds: pre-counting them would give a wrong
+        // expectedUnits denominator. Must fall back to the count-only heartbeat.
+        Path docx = tmp.newFile("fake.docx").toPath();
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(docx))) {
+            zos.putNextEntry(new ZipEntry("[Content_Types].xml"));
+            zos.write("<Types/>".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("word/document.xml"));
+            zos.write("<document/>".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        ExtractionProgress progress = new ExtractionProgress(docx, 0L);
+        new Extractor().applyArchiveUnitCount(docx, progress);
+        assertThat(progress.expectedUnits()).isEqualTo(-1L);
+    }
 }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorArchiveUnitsTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorArchiveUnitsTest.java
@@ -1,0 +1,39 @@
+package org.icij.extract.extractor;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ExtractorArchiveUnitsTest {
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test public void testApplyArchiveUnitCountSetsZipEntryTotal() throws Exception {
+        Path zip = tmp.newFile("a.zip").toPath();
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip))) {
+            for (int i = 0; i < 4; i++) {
+                zos.putNextEntry(new ZipEntry("f" + i + ".txt"));
+                zos.write(("v" + i).getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+        }
+        ExtractionProgress progress = new ExtractionProgress(zip, 0L);
+        new Extractor().applyArchiveUnitCount(zip, progress);
+        assertThat(progress.expectedUnits()).isEqualTo(4L);
+    }
+
+    @Test public void testApplyArchiveUnitCountLeavesNonArchiveUnknown() throws Exception {
+        Path txt = tmp.newFile("plain.txt").toPath();
+        Files.write(txt, "hi".getBytes(StandardCharsets.UTF_8));
+        ExtractionProgress progress = new ExtractionProgress(txt, 0L);
+        new Extractor().applyArchiveUnitCount(txt, progress);
+        assertThat(progress.expectedUnits()).isEqualTo(-1L);
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/LoggingProgressListenerTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/LoggingProgressListenerTest.java
@@ -74,4 +74,28 @@ public class LoggingProgressListenerTest {
         }
         assertThat(appender.list).hasSize(2);
     }
+
+    @Test public void testFormatLineShowsEstimateWhenUnitsKnown() {
+        ExtractionProgress p = new ExtractionProgress(Paths.get("/foo.ost"), 0L);
+        for (int i = 0; i < 300; i++) p.incrementEmbeds();   // 300 embeds so far
+        for (int i = 0; i < 3; i++) p.incrementUnits();      // 3 of ...
+        p.setExpectedUnits(4L);                              // ... 4 units => 75%
+        // estTotal = round(300 * 4 / 3) = 400
+        assertThat(LoggingProgressListener.formatLine(p, 1_000L))
+            .isEqualTo("/foo.ost: 1s, 300/~400 embeds (~75%), 0/0 OCR done, 0 skipped(maxDepth), 0 skipped(maxSize)");
+    }
+
+    @Test public void testFormatLineFallsBackWhenUnitsUnknown() {
+        ExtractionProgress p = new ExtractionProgress(Paths.get("/logs.tar.gz"), 0L);
+        p.incrementEmbeds();
+        assertThat(LoggingProgressListener.formatLine(p, 1_000L))
+            .isEqualTo("/logs.tar.gz: 1s, 1 embeds, 0/0 OCR done, 0 skipped(maxDepth), 0 skipped(maxSize)");
+    }
+
+    @Test public void testFormatLineFallsBackBeforeFirstUnit() {
+        ExtractionProgress p = new ExtractionProgress(Paths.get("/foo.ost"), 0L);
+        p.incrementEmbeds();
+        p.setExpectedUnits(10L);   // total known, but unitsParsed == 0 -> no divide, fall back
+        assertThat(LoggingProgressListener.formatLine(p, 1_000L)).contains("1 embeds,");
+    }
 }

--- a/extract-lib/src/test/java/org/icij/extract/parser/ResilientOutlookPSTParserTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/parser/ResilientOutlookPSTParserTest.java
@@ -349,7 +349,8 @@ public class ResilientOutlookPSTParserTest {
         assertThat(progress.parserTracksUnits()).isTrue();
         assertThat(progress.expectedUnits()).isGreaterThan(0L);
         assertThat(progress.unitsParsed()).isGreaterThan(0L);
-        // The numerator equals the parser's own emitted-message count and never exceeds the total.
-        assertThat(progress.unitsParsed()).isLessThanOrEqualTo(progress.expectedUnits());
+        // The fixture has message loss (expected 7, emitted 6), but the completed parse snaps the
+        // numerator to the total, so the reading is a clean 100%, not stuck just below.
+        assertThat(progress.unitsParsed()).isEqualTo(progress.expectedUnits());
     }
 }

--- a/extract-lib/src/test/java/org/icij/extract/parser/ResilientOutlookPSTParserTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/parser/ResilientOutlookPSTParserTest.java
@@ -327,4 +327,29 @@ public class ResilientOutlookPSTParserTest {
             .forEach(m -> assertThat(m.get(org.apache.tika.metadata.TikaCoreProperties.EMBEDDED_RELATIONSHIP_ID))
                     .matches("-?\\d+-\\d+"));
     }
+
+    private org.icij.extract.extractor.ExtractionProgress parseWithProgress(Path file) throws Exception {
+        ResilientOutlookPSTParser parser = new ResilientOutlookPSTParser();
+        CountingExtractor counting = new CountingExtractor();
+        org.icij.extract.extractor.ExtractionProgress progress =
+                new org.icij.extract.extractor.ExtractionProgress(file, 0L);
+        ParseContext context = new ParseContext();
+        context.set(Parser.class, parser);
+        context.set(EmbeddedDocumentExtractor.class, counting);
+        context.set(org.icij.extract.extractor.ExtractionProgress.class, progress);
+        Metadata metadata = new Metadata();
+        try (InputStream is = TikaInputStream.get(file, metadata)) {
+            parser.parse(is, new BodyContentHandler(-1), metadata, context);
+        }
+        return progress;
+    }
+
+    @Test public void testPstPublishesMessageTotalAndNumerator() throws Exception {
+        org.icij.extract.extractor.ExtractionProgress progress = parseWithProgress(testPst());
+        assertThat(progress.parserTracksUnits()).isTrue();
+        assertThat(progress.expectedUnits()).isGreaterThan(0L);
+        assertThat(progress.unitsParsed()).isGreaterThan(0L);
+        // The numerator equals the parser's own emitted-message count and never exceeds the total.
+        assertThat(progress.unitsParsed()).isLessThanOrEqualTo(progress.expectedUnits());
+    }
 }


### PR DESCRIPTION
Adds a best-effort completion estimate to the per-file progress heartbeat so operators can tell "70% in" from "wedged" during long OST/archive extractions. Containers with a cheap up-front total (PST/OST messages, ZIP/7z entries) get `N/~M embeds (~P%)`; everything else keeps the current count-only line. The percentage is driven by ground-truth counts (`~` marks the projected embed total).

- feat: add unit counters (expected/parsed + parser-tracks flag) to `ExtractionProgress`
- feat: render projected embed total and percentage in `LoggingProgressListener`, with count-only fallback
- feat: cheap ZIP/7z central-directory pre-count (`ArchiveEntryCounter`), excluding OOXML/ODF/EPUB container docs (parsed by dedicated parsers, not PackageParser)
- feat: PST/OST publishes its enumerated message total and live numerator via the Tika `ParseContext` + shared reconciliation across parallel folder forks
- feat: count depth-1 archive entries as units (including size-guard-skipped ones) so archives reach 100%
- fix: snap the PST unit count to 100% on parse completion, so lossy OSTs no longer stick below 100%
- fix: require a STORED `mimetype` to classify a zip as a container doc, avoiding false positives on genuine archives

Scope notes: the estimate is best-effort. A top-level entry that is itself a nested container reads high early, and entries filtered by a DocumentSelector can plateau below 100% (not the case in normal indexing). 