### PR TITLE
feat(spew): root-stub-first, make the container root visible during a long parse

### DIFF
--- a/extract-lib/src/main/java/org/icij/spewer/Spewer.java
+++ b/extract-lib/src/main/java/org/icij/spewer/Spewer.java
@@ -68,9 +68,11 @@ public abstract class Spewer implements AutoCloseable, Serializable {
      * @param root            the container root whose full write never happened
      * @param writtenChildren the number of embedded children actually written to the endpoint before
      *                        the abort, so the stub can record how much of the container was recovered
+     * @return {@code true} if a stub row was actually written, {@code false} if the call was a no-op
+     *         (e.g. the root already exists so writing a contentless stub would clobber it)
      */
-    protected void writeRootStub(final TikaDocument root, final long writtenChildren) throws IOException {
-        // no-op by default
+    protected boolean writeRootStub(final TikaDocument root, final long writtenChildren) throws IOException {
+        return false; // no-op by default: nothing was written
     }
 
     /**
@@ -86,6 +88,21 @@ public abstract class Spewer implements AutoCloseable, Serializable {
      * @param writtenChildren the total number of embedded children written under this root
      */
     protected void finalizeRoot(final TikaDocument root, final long writtenChildren) throws IOException {
+        // no-op by default
+    }
+
+    /**
+     * Refresh the child count on a container ROOT still represented by its early PARTIAL stub because
+     * the parse aborted after the stub was written (see {@link #writeRootStub}) but before the real
+     * root write. Unlike {@link #finalizeRoot}, this must NOT mark the root complete: the parse did not
+     * finish, so the root stays PARTIAL. Called at most once per aborted root, after the worker drained.
+     *
+     * <p>Default no-op.
+     *
+     * @param root            the container root still represented by its early PARTIAL stub
+     * @param writtenChildren the number of embedded children written before the abort
+     */
+    protected void finalizeAbortedRoot(final TikaDocument root, final long writtenChildren) throws IOException {
         // no-op by default
     }
 

--- a/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
+++ b/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
@@ -42,6 +42,7 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
     // those embeds from being orphaned. rootWritten is set once the real root is written by spew().
     private volatile TikaDocument seenRoot;
     private volatile boolean rootWritten;
+    private volatile boolean rootStubWritten;
 
     public StreamingSpewCoordinator(final Spewer spewer, final int queueCapacity) {
         this.spewer = spewer;
@@ -107,7 +108,7 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
             // count and mark it complete. Best-effort: a finalize failure must not mask the parse result.
             // Skip finalize when the thread was interrupted (parse cancelled): awaitDrained may have
             // returned early, so writtenEmbeds is not final, and a cancelled container must not be
-            // recorded as a fully-processed one. The aborted-root path (writeRootStubIfOrphaned) covers
+            // recorded as a fully-processed one. The aborted-root path (finalizeOrStubAbortedRoot) covers
             // orphaned children instead.
             if (rootWritten && !root.isDuplicate() && writtenEmbeds.get() > 0
                     && !Thread.currentThread().isInterrupted()) {
@@ -137,6 +138,7 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
                 final SpewItem item = (SpewItem) o;
                 if (seenRoot == null) {
                     seenRoot = item.root();
+                    writeEarlyRootStub();
                 }
                 try {
                     // Skip children of a duplicate root, matching the legacy tree walk's gating.
@@ -156,6 +158,27 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
             }
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Write the container root as a contentless PARTIAL stub as soon as the parse begins emitting
+     * children, so the root is visible in the index during a long parse instead of only at the end
+     * (the foreground is blocked reading the root's content the whole time). Best-effort and once per
+     * parse, on the worker thread. The end-of-parse real root write (same id+path) later overwrites the
+     * stub with full content, and finalizeRoot marks it complete. A duplicate root needs no stub (its
+     * children are skipped). The !rootWritten guard avoids clobbering an already-written real root in
+     * the degenerate case where the root body was read before the first child was drained.
+     */
+    private void writeEarlyRootStub() {
+        final TikaDocument root = seenRoot;
+        if (rootStubWritten || rootWritten || root == null || root.isDuplicate()) {
+            return;
+        }
+        try {
+            rootStubWritten = spewer.writeRootStub(root, writtenEmbeds.get());
+        } catch (final Throwable t) {
+            logger.error("failed to write early root stub for {}", root.getId(), t);
         }
     }
 
@@ -204,28 +227,34 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
     @Override
     public void close() {
         shutdownWorker();
-        writeRootStubIfOrphaned();
+        finalizeOrStubAbortedRoot();
     }
 
     /**
-     * If the parse aborted before the foreground wrote the real root (spew() never ran to completion)
-     * yet embeds were already streamed to the index, write a contentless root stub so those embeds are
-     * not orphaned under a non-existent root. Best-effort and idempotent; runs after the worker drained,
-     * so writtenEmbeds/seenRoot are final. A duplicate root needs no stub (its children were skipped).
+     * On close after an aborted parse (the foreground never completed the real root write), keep the
+     * streamed children from being orphaned and record their count. If this run's early stub was
+     * written, refresh its child count while keeping it PARTIAL; otherwise write the stub now (fallback
+     * when the early stub failed, or when writeRootStub reported the root already existed so we must not
+     * refresh a pre-existing complete root's count). Best-effort; runs after the worker drained, so
+     * writtenEmbeds/seenRoot are final. A duplicate root or a root with no written children needs
+     * nothing.
      */
-    private void writeRootStubIfOrphaned() {
+    private void finalizeOrStubAbortedRoot() {
         if (rootWritten) {
-            return;
+            return; // the real root was written; the happy path already finalized it
         }
         final TikaDocument root = seenRoot;
         if (root == null || root.isDuplicate() || writtenEmbeds.get() == 0) {
             return;
         }
         try {
-            spewer.writeRootStub(root, writtenEmbeds.get());
-            rootWritten = true;
+            if (rootStubWritten) {
+                spewer.finalizeAbortedRoot(root, writtenEmbeds.get());
+            } else {
+                rootStubWritten = spewer.writeRootStub(root, writtenEmbeds.get());
+            }
         } catch (final Throwable t) {
-            logger.error("failed to write root stub for aborted parse of {}", root.getId(), t);
+            logger.error("failed to finalize/stub aborted root {}", root.getId(), t);
         }
     }
 

--- a/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
+++ b/extract-lib/src/main/java/org/icij/spewer/StreamingSpewCoordinator.java
@@ -37,12 +37,16 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
     private final Object drainLock = new Object();
     private volatile Throwable workerError;
     private volatile Thread worker;
-    // The root the streamed embeds belong to, captured off the worker as it writes them, so that on an
-    // aborted parse (the foreground never reaches spew()) close() can still write a root stub and keep
-    // those embeds from being orphaned. rootWritten is set once the real root is written by spew().
+    // The root the streamed embeds belong to, captured off the worker as it writes them. It drives two
+    // things: writeEarlyRootStub() makes the root visible in the index as soon as the first child is
+    // written (during a long parse), and on close() after an aborted parse (the foreground never
+    // reaches spew()) finalizeOrStubAbortedRoot() refreshes that stub's child count -- or, if no stub
+    // was written, writes one -- so the streamed embeds are not orphaned. rootWritten is set once the
+    // real root is written by spew(); rootStubWritten tracks whether this run's PARTIAL stub was written.
     private volatile TikaDocument seenRoot;
     private volatile boolean rootWritten;
     private volatile boolean rootStubWritten;
+    private volatile boolean closed;
 
     public StreamingSpewCoordinator(final Spewer spewer, final int queueCapacity) {
         this.spewer = spewer;
@@ -138,13 +142,17 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
                 final SpewItem item = (SpewItem) o;
                 if (seenRoot == null) {
                     seenRoot = item.root();
-                    writeEarlyRootStub();
                 }
                 try {
                     // Skip children of a duplicate root, matching the legacy tree walk's gating.
                     if (!item.root().isDuplicate()) {
                         spewer.writeDocument(item.embed(), item.parent(), item.root(), item.level());
                         writtenEmbeds.incrementAndGet();
+                        // Only after the first child is durably indexed: a stub must never outlive a
+                        // parse that wrote zero children (that would leave a contentless PARTIAL ghost
+                        // root on abort). writeEarlyRootStub() is idempotent, so calling it per child is
+                        // fine -- only the first call writes.
+                        writeEarlyRootStub();
                     }
                 } catch (final Throwable t) {
                     if (workerError == null) {
@@ -162,8 +170,8 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
     }
 
     /**
-     * Write the container root as a contentless PARTIAL stub as soon as the parse begins emitting
-     * children, so the root is visible in the index during a long parse instead of only at the end
+     * Write the container root as a contentless PARTIAL stub as soon as the first child is durably
+     * indexed, so the root is visible in the index during a long parse instead of only at the end
      * (the foreground is blocked reading the root's content the whole time). Best-effort and once per
      * parse, on the worker thread. The end-of-parse real root write (same id+path) later overwrites the
      * stub with full content, and finalizeRoot marks it complete. A duplicate root needs no stub (its
@@ -226,6 +234,10 @@ public class StreamingSpewCoordinator implements SpewSink, AutoCloseable {
 
     @Override
     public void close() {
+        if (closed) {
+            return; // idempotent: a second close() must not re-invoke the endpoint for the same root
+        }
+        closed = true;
         shutdownWorker();
         finalizeOrStubAbortedRoot();
     }

--- a/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
+++ b/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
@@ -203,14 +203,53 @@ public class StreamingSpewCoordinatorTest {
             coord.ready(new SpewItem(e1, root, root, 1));
         }
 
-        // The early stub made the root visible at the first child (count 0 at that point). On abort the
-        // real root was never written, so close() refreshes the count on the still-PARTIAL stub with the
-        // final drained value (1) rather than writing a second stub.
+        // The early stub is written only after the first child is durably indexed (count 1 at that
+        // point). On abort the real root was never written, so close() refreshes the count on the
+        // still-PARTIAL stub with the final drained value (1) rather than writing a second stub.
         assertThat(spewer.written).contains("e1");
         assertThat(spewer.rootStubs).containsOnly("root");
-        assertThat(spewer.rootStubChildCounts).containsOnly(0L);
+        assertThat(spewer.rootStubChildCounts).containsOnly(1L);
         assertThat(spewer.finalizedAbortedRoots).containsOnly("root");
         assertThat(spewer.finalizeAbortedChildCounts).containsOnly(1L);
+    }
+
+    @Test
+    public void testAbortWithOnlyChildFailingWritesNoGhostRoot() throws Exception {
+        RecordingSpewer spewer = new RecordingSpewer();
+        spewer.failOnId = "e1"; // the only/first child fails to write
+        TikaDocument root = doc("root", new StringReader("root-body"));
+        TikaDocument e1 = doc("e1", new StringReader("a"));
+
+        try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
+            coord.start();
+            coord.promise();
+            coord.ready(new SpewItem(e1, root, root, 1));
+            // parse aborts before the foreground writes the root: spew() never called.
+        }
+
+        // The only child failed to write (writtenEmbeds stays 0), so no stub is ever written and the
+        // abort path leaves nothing behind -- no contentless PARTIAL "ghost" root, matching pre-feature
+        // behavior.
+        assertThat(spewer.written).excludes("e1");
+        assertThat(spewer.rootStubs).isEmpty();
+        assertThat(spewer.finalizedAbortedRoots).isEmpty();
+    }
+
+    @Test
+    public void testCloseIsIdempotentOnAbortedRoot() throws Exception {
+        RecordingSpewer spewer = new RecordingSpewer();
+        TikaDocument root = doc("root", new StringReader("root-body"));
+        TikaDocument e1 = doc("e1", new StringReader("a"));
+
+        StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16);
+        coord.start();
+        coord.promise();
+        coord.ready(new SpewItem(e1, root, root, 1));
+        coord.close();
+        coord.close(); // a second close must not refresh the aborted root a second time
+
+        assertThat(spewer.finalizedAbortedRoots).containsOnly("root");
+        assertThat(spewer.finalizeAbortedChildCounts).hasSize(1);
     }
 
     @Test

--- a/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
+++ b/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
@@ -113,8 +113,6 @@ public class StreamingSpewCoordinatorTest {
         assertThat(spewer.written).contains("root", "e1", "e2");
         assertThat(spewer.finalizedRoots).containsOnly("root");
         assertThat(spewer.finalizeChildCounts).containsOnly(2L);
-        // The normal path never writes a stub.
-        assertThat(spewer.rootStubs).isEmpty();
     }
 
     @Test
@@ -162,42 +160,78 @@ public class StreamingSpewCoordinatorTest {
     }
 
     @Test
-    public void testWritesRootStubWhenParseAbortsBeforeRootIsWritten() throws Exception {
+    public void testWritesEarlyRootStubOnNormalCompletionThenFinalizes() throws Exception {
         RecordingSpewer spewer = new RecordingSpewer();
         TikaDocument root = doc("root", new StringReader("root-body"));
         TikaDocument e1 = doc("e1", new StringReader("a"));
 
         try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
-            // Production starts the worker before the parse; simulate that so the embed drains while
-            // the parse runs. The parse then throws (timeout/cancel) BEFORE the foreground wrote the
-            // root: spew(root) is never called; close() runs via try-with-resources.
+            coord.start();
+            coord.promise();
+            coord.ready(new SpewItem(e1, root, root, 1));
+            // Wait until the worker has drained the first child; the early stub is written just before
+            // that child, so writtenCount() >= 1 proves the stub was already written -- and the real
+            // root has NOT been written yet (spew() not yet called), so the stub was not suppressed.
+            for (int i = 0; i < 200 && coord.writtenCount() < 1; i++) {
+                Thread.sleep(5);
+            }
+            assertThat(coord.writtenCount()).isEqualTo(1L);
+            assertThat(spewer.rootStubs).containsOnly("root"); // visible up front, before the real root
+
+            coord.spew(root); // foreground now writes the real root, driving completion
+        }
+
+        // Real root written + at least one child -> finalized COMPLETE with the final count; the early
+        // stub is NOT re-written and the abort refresh does not run.
+        assertThat(spewer.written).contains("root", "e1");
+        assertThat(spewer.finalizedRoots).containsOnly("root");
+        assertThat(spewer.finalizeChildCounts).containsOnly(1L);
+        assertThat(spewer.finalizedAbortedRoots).isEmpty();
+    }
+
+    @Test
+    public void testAbortAfterEarlyStubRefreshesChildCountKeepingPartial() throws Exception {
+        RecordingSpewer spewer = new RecordingSpewer();
+        TikaDocument root = doc("root", new StringReader("root-body"));
+        TikaDocument e1 = doc("e1", new StringReader("a"));
+
+        try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
+            // Worker starts before the parse; the parse aborts (timeout/cancel) BEFORE the foreground
+            // writes the root: spew(root) is never called, close() runs via try-with-resources.
             coord.start();
             coord.promise();
             coord.ready(new SpewItem(e1, root, root, 1));
         }
 
-        // The embed was written; the root would be orphaned, so close() must write a stub for it,
-        // recording the number of children actually written (1) so the root can be marked partial.
+        // The early stub made the root visible at the first child (count 0 at that point). On abort the
+        // real root was never written, so close() refreshes the count on the still-PARTIAL stub with the
+        // final drained value (1) rather than writing a second stub.
         assertThat(spewer.written).contains("e1");
-        assertThat(spewer.rootStubs).contains("root");
-        assertThat(spewer.rootStubChildCounts).containsOnly(1L);
+        assertThat(spewer.rootStubs).containsOnly("root");
+        assertThat(spewer.rootStubChildCounts).containsOnly(0L);
+        assertThat(spewer.finalizedAbortedRoots).containsOnly("root");
+        assertThat(spewer.finalizeAbortedChildCounts).containsOnly(1L);
     }
 
     @Test
-    public void testDoesNotWriteRootStubOnNormalCompletion() throws Exception {
+    public void testAbortDoesNotRefreshCountWhenEarlyStubReportedRootAlreadyExists() throws Exception {
         RecordingSpewer spewer = new RecordingSpewer();
+        spewer.rootStubExists = true; // e.g. a prior COMPLETE root already indexed (reindex): stub is a no-op
         TikaDocument root = doc("root", new StringReader("root-body"));
         TikaDocument e1 = doc("e1", new StringReader("a"));
 
         try (StreamingSpewCoordinator coord = new StreamingSpewCoordinator(spewer, 16)) {
+            coord.start();
             coord.promise();
             coord.ready(new SpewItem(e1, root, root, 1));
-            coord.spew(root); // foreground writes the real root
+            // parse aborts before the foreground writes the root: spew() never called.
         }
 
-        // The real root was written; no stub is needed.
-        assertThat(spewer.written).contains("root", "e1");
-        assertThat(spewer.rootStubs).isEmpty();
+        // writeRootStub reported "not written" (root already exists), so rootStubWritten stayed false and
+        // the abort path must NOT call finalizeAbortedRoot -- refreshing the count would regress a prior
+        // COMPLETE root. It falls back to writeRootStub, itself a no-op against the existing root.
+        assertThat(spewer.finalizedAbortedRoots).isEmpty();
+        assertThat(spewer.rootStubs).contains("root"); // attempted early + fallback, both no-ops
     }
 
     @Test

--- a/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
+++ b/extract-lib/src/test/java/org/icij/spewer/StreamingSpewCoordinatorTest.java
@@ -38,10 +38,13 @@ public class StreamingSpewCoordinatorTest {
             written.add(doc.getId());
         }
 
+        volatile boolean rootStubExists = false; // simulate a root already indexed (reindex): stub write is a no-op
+
         @Override
-        protected void writeRootStub(TikaDocument root, long writtenChildren) {
+        protected boolean writeRootStub(TikaDocument root, long writtenChildren) {
             rootStubs.add(root.getId());
             rootStubChildCounts.add(writtenChildren);
+            return !rootStubExists;
         }
 
         final List<String> finalizedRoots = Collections.synchronizedList(new ArrayList<>());
@@ -51,6 +54,15 @@ public class StreamingSpewCoordinatorTest {
         protected void finalizeRoot(TikaDocument root, long writtenChildren) {
             finalizedRoots.add(root.getId());
             finalizeChildCounts.add(writtenChildren);
+        }
+
+        final List<String> finalizedAbortedRoots = Collections.synchronizedList(new ArrayList<>());
+        final List<Long> finalizeAbortedChildCounts = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        protected void finalizeAbortedRoot(TikaDocument root, long writtenChildren) {
+            finalizedAbortedRoots.add(root.getId());
+            finalizeAbortedChildCounts.add(writtenChildren);
         }
     }
 


### PR DESCRIPTION
When indexing a big OST/PST/archive with streaming spew, the container root is written last (reading its content drives the whole parse), so for hours the embedded children stream into the index while the root itself is absent. This makes the root visible up front as a contentless PARTIAL stub at the first child, then enriches it to COMPLETE at parse end (or refreshes its child count if the parse aborts).

Extract-lib half only; the datashare side (extract.version bump + ElasticsearchSpewer overrides) follows after a release.

- refactor(spew): `writeRootStub` returns whether it wrote, and add a `finalizeAbortedRoot` hook
- feat(spew): write the container root stub at the first drained child, then finalize it after the drain
- fix(spew): write the stub only after the first child is durably indexed (no contentless "ghost" root when a first/only child fails), make `close()` idempotent
