### PR TITLE
Unify embedded-artifact write layout across the two writers

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -778,7 +778,6 @@ public class EmbedSpawner extends EmbedParser {
 	}
 
 	private void writeEmbed(final TikaInputStream tis, final EmbeddedTikaDocument embed, final String name) throws IOException {
-		final Path destination = outputPath.resolve(embed.getHash());
 		final Path source;
 
 		final Metadata metadata = embed.getMetadata();
@@ -805,17 +804,11 @@ public class EmbedSpawner extends EmbedParser {
 			metadata.set(Metadata.CONTENT_LENGTH, Long.toString(Files.size(source)));
 		}
 
-		// To prevent massive duplication and because the disk is only a storage for underlying data, save using the
-		// straight hash as a filename.
-		try {
-			Files.copy(source, destination);
-		} catch (final FileAlreadyExistsException e) {
-			if (Files.size(source) != Files.size(destination)) {
-				Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
-			} else {
-				logger.info("Temporary file for document \"{}\" in \"{}\" already exists.", name, root);
-			}
-		}
+		// Write the raw payload and its raw.json sidecar in the content-addressed layout, keyed by the
+		// embed id (NOT the raw file digest). This is the same layout and key EmbeddedDocumentExtractor
+		// uses, so an id-addressed manifest and datashare's on-demand SourceExtractor resolve to these
+		// exact bytes. The name is used only for the log breadcrumb on failure (see the call sites).
+		EmbeddedArtifactWriter.write(outputPath, embed.getId(), metadata, source);
 	}
 
 	static boolean isOcrEligible(final Metadata metadata, final long minImageBytes) {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedSpawner.java
@@ -804,11 +804,45 @@ public class EmbedSpawner extends EmbedParser {
 			metadata.set(Metadata.CONTENT_LENGTH, Long.toString(Files.size(source)));
 		}
 
-		// Write the raw payload and its raw.json sidecar in the content-addressed layout, keyed by the
-		// embed id (NOT the raw file digest). This is the same layout and key EmbeddedDocumentExtractor
-		// uses, so an id-addressed manifest and datashare's on-demand SourceExtractor resolve to these
-		// exact bytes. The name is used only for the log breadcrumb on failure (see the call sites).
-		EmbeddedArtifactWriter.write(outputPath, embed.getId(), metadata, source);
+		final String id = embed.getId();
+		if (isContentAddressableId(id)) {
+			// Content-addressed layout (datashare / DigestIdentifier): raw + raw.json under xx/yy/<id>,
+			// keyed by the embed id, matching EmbeddedDocumentExtractor so a manifest and datashare's
+			// on-demand SourceExtractor resolve to these exact bytes.
+			EmbeddedArtifactWriter.write(outputPath, id, metadata, source);
+		} else {
+			// Legacy flat dump (extract-cli --embedOutput under PathIdentifier): the id is a filesystem
+			// path, not a shardable content digest, so keep the historical behavior of writing a single
+			// flat file named by the raw content hash. Preserves the "output attachments en masse" CLI
+			// feature unchanged for non-content-addressable ids.
+			final Path destination = outputPath.resolve(embed.getHash());
+			try {
+				Files.copy(source, destination);
+			} catch (final FileAlreadyExistsException e) {
+				if (Files.size(source) != Files.size(destination)) {
+					Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+				} else {
+					logger.info("Temporary file for document \"{}\" in \"{}\" already exists.", name, root);
+				}
+			}
+		}
+	}
+
+	// A content-addressable id is the lowercase-hex digest composite produced by DigestIdentifier /
+	// PathDigestIdentifier; it can be safely sharded into xx/yy/<id> (see ArtifactUtils.getEmbeddedPath).
+	// PathIdentifier instead yields the document's filesystem path, which is neither hex nor shard-safe
+	// (an absolute path escapes the artifact dir), so those ids take the legacy flat write in writeEmbed.
+	static boolean isContentAddressableId(final String id) {
+		if (id == null || id.length() < 4) {
+			return false;
+		}
+		for (int i = 0; i < id.length(); i++) {
+			final char c = id.charAt(i);
+			if ((c < '0' || c > '9') && (c < 'a' || c > 'f')) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	static boolean isOcrEligible(final Metadata metadata, final long minImageBytes) {

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedArtifactWriter.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedArtifactWriter.java
@@ -1,0 +1,61 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.icij.spewer.MetadataTransformer;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+// Single owner of the content-addressed raw layout for an embedded document's bytes.
+// Both writers (the streaming EmbedSpawner and the on-demand EmbeddedDocumentExtractor) go
+// through here so their on-disk layout, sidecar format and key can never drift apart.
+// The layout is: payload at getEmbeddedPath(artifactPath, id)/raw and sidecar at raw.json,
+// keyed by the embed id (NOT the raw file digest), so a manifest and the serving layer that
+// resolve by id find the bytes this class writes.
+class EmbeddedArtifactWriter {
+
+    private EmbeddedArtifactWriter() {}
+
+    // artifactPath/<id[0:2]>/<id[2:4]>/<id>/raw
+    static Path rawPath(final Path artifactPath, final String id) {
+        return ArtifactUtils.getEmbeddedPath(artifactPath, id).resolve("raw");
+    }
+
+    // Copy already-spooled bytes into the raw payload (overwriting) and write the raw.json sidecar.
+    static File write(final Path artifactPath, final String id, final Metadata metadata, final Path source) throws IOException {
+        final File embedded = rawPath(artifactPath, id).toFile();
+        Files.createDirectories(Paths.get(embedded.getParent()));
+        Files.copy(source, embedded.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        try (FileOutputStream metadataOutputStream = new FileOutputStream(embedded + ".json")) {
+            metadataOutputStream.write(new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
+        }
+        return embedded;
+    }
+
+    // Stream the embed bytes into the raw payload (8K buffer) and write the raw.json sidecar, then
+    // reset the stream so the caller can reuse it. Mirrors EmbeddedDocumentExtractor's prior writeFile(tis).
+    // Marks the stream itself before reading so reset() below is always valid, regardless of whether
+    // the caller already marked it.
+    static File write(final Path artifactPath, final String id, final Metadata metadata, final TikaInputStream tis) throws IOException {
+        final File embedded = rawPath(artifactPath, id).toFile();
+        Files.createDirectories(Paths.get(embedded.getParent()));
+        tis.mark(0);
+        try (FileOutputStream embeddedOutputStream = new FileOutputStream(embedded);
+             FileOutputStream metadataOutputStream = new FileOutputStream(embedded + ".json")) {
+            int nbTmpBytesRead;
+            for (byte[] tmp = new byte[8192]; (nbTmpBytesRead = tis.read(tmp)) > 0; ) {
+                embeddedOutputStream.write(tmp, 0, nbTmpBytesRead);
+            }
+            metadataOutputStream.write(new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
+        }
+        tis.reset();
+        return embedded;
+    }
+}

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedArtifactWriter.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedArtifactWriter.java
@@ -42,7 +42,10 @@ class EmbeddedArtifactWriter {
     // Stream the embed bytes into the raw payload (8K buffer) and write the raw.json sidecar, then
     // reset the stream so the caller can reuse it. Mirrors EmbeddedDocumentExtractor's prior writeFile(tis).
     // Marks the stream itself before reading so reset() below is always valid, regardless of whether
-    // the caller already marked it.
+    // the caller already marked it. Callers pass a file-backed TikaInputStream (spooled to disk), for
+    // which mark/reset re-seeks the file and the readlimit is ignored; the 0 readlimit is therefore safe
+    // here and would only be a concern for a purely in-memory, non-file-backed stream, which never reaches
+    // this overload (EmbeddedDocumentExtractor's callers spool first; EmbedSpawner uses the Path overload).
     static File write(final Path artifactPath, final String id, final Metadata metadata, final TikaInputStream tis) throws IOException {
         final File embedded = rawPath(artifactPath, id).toFile();
         Files.createDirectories(Paths.get(embedded.getParent()));

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -23,10 +23,8 @@ import org.xml.sax.SAXException;
 
 import java.io.*;
 import java.lang.module.ModuleDescriptor;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.LinkedList;
 import java.util.function.Supplier;
@@ -118,7 +116,7 @@ public class EmbeddedDocumentExtractor {
     }
 
     static Path getEmbeddedPath(Path artifactPath, String digest) {
-        return ArtifactUtils.getEmbeddedPath(artifactPath, digest).resolve("raw");
+        return EmbeddedArtifactWriter.rawPath(artifactPath, digest);
     }
 
     private static abstract class DigestEmbeddedDocumentExtractor extends EmbedParser {
@@ -226,28 +224,11 @@ public class EmbeddedDocumentExtractor {
         }
 
         protected File writeFile(Metadata metadata, String digest, TikaInputStream tis) throws IOException {
-            File embedded = getEmbeddedPath(this.artifactPath, digest).toFile();
-            Files.createDirectories(Paths.get(embedded.getParent()));
-            try (FileOutputStream embeddedOutputStream = new FileOutputStream(embedded);
-                 FileOutputStream metadataOutputStream = new FileOutputStream(embedded + ".json")) {
-                int nbTmpBytesRead;
-                for (byte[] tmp = new byte[8192]; (nbTmpBytesRead = tis.read(tmp)) > 0; ) {
-                    embeddedOutputStream.write(tmp, 0, nbTmpBytesRead); // streams in a file (using 8K memory buffer)
-                }
-                metadataOutputStream.write(new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
-            }
-            tis.reset();
-            return embedded;
+            return EmbeddedArtifactWriter.write(this.artifactPath, digest, metadata, tis);
         }
 
         protected File writeFile(Metadata metadata, String digest, Path source) throws IOException {
-            File embedded = getEmbeddedPath(this.artifactPath, digest).toFile();
-            Files.createDirectories(Paths.get(embedded.getParent()));
-            Files.copy(source, embedded.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            try (FileOutputStream metadataOutputStream = new FileOutputStream(embedded + ".json")) {
-                metadataOutputStream.write(new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
-            }
-            return embedded;
+            return EmbeddedArtifactWriter.write(this.artifactPath, digest, metadata, source);
         }
     }
 

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerEligibilityTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedSpawnerEligibilityTest.java
@@ -68,4 +68,35 @@ public class EmbedSpawnerEligibilityTest {
     @Test public void testDepthOneBelowLimitIsAllowed() {
         assertThat(EmbedSpawner.exceedsMaxEmbedDepth(1, 20)).isFalse();
     }
+
+    @Test public void testLongLowercaseHexDigestIsContentAddressable() {
+        assertThat(EmbedSpawner.isContentAddressableId(
+                "1eeb334ca60c61baca50b9df851b60c52b856c727932d0d1cae4e56a34190e7e")).isTrue();
+    }
+
+    @Test public void testShortLowercaseHexIsContentAddressable() {
+        assertThat(EmbedSpawner.isContentAddressableId("abcd")).isTrue();
+    }
+
+    @Test public void testFilesystemPathIsNotContentAddressable() {
+        // PathIdentifier case: getId() returns the document's filesystem path.
+        assertThat(EmbedSpawner.isContentAddressableId("/home/user/doc.pdf")).isFalse();
+    }
+
+    @Test public void testUppercaseHexIsNotContentAddressable() {
+        // DigestIdentifier ids are always lowercased.
+        assertThat(EmbedSpawner.isContentAddressableId("ABCD")).isFalse();
+    }
+
+    @Test public void testNullIsNotContentAddressable() {
+        assertThat(EmbedSpawner.isContentAddressableId(null)).isFalse();
+    }
+
+    @Test public void testEmptyStringIsNotContentAddressable() {
+        assertThat(EmbedSpawner.isContentAddressableId("")).isFalse();
+    }
+
+    @Test public void testTooShortHexIsNotContentAddressable() {
+        assertThat(EmbedSpawner.isContentAddressableId("abc")).isFalse();
+    }
 }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedArtifactWriterTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedArtifactWriterTest.java
@@ -1,0 +1,86 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.icij.spewer.MetadataTransformer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class EmbeddedArtifactWriterTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private static final String ID = "abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890";
+
+    private Metadata metadataWithName(String name) {
+        Metadata metadata = new Metadata();
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+        return metadata;
+    }
+
+    @Test
+    public void test_rawPath_is_content_addressed_with_raw_leaf() {
+        Path root = tmp.getRoot().toPath();
+        assertThat(EmbeddedArtifactWriter.rawPath(root, ID).toFile())
+                .isEqualTo(root.resolve("ab").resolve("cd").resolve(ID).resolve("raw").toFile());
+    }
+
+    @Test
+    public void test_write_from_path_creates_raw_and_sidecar() throws Exception {
+        Path root = tmp.getRoot().toPath();
+        Path source = tmp.newFile("payload.bin").toPath();
+        Files.write(source, "hello".getBytes());
+        Metadata metadata = metadataWithName("payload.bin");
+
+        File written = EmbeddedArtifactWriter.write(root, ID, metadata, source);
+
+        assertThat(written).isEqualTo(EmbeddedArtifactWriter.rawPath(root, ID).toFile());
+        assertThat(written).isFile();
+        assertThat(Files.readAllBytes(written.toPath())).isEqualTo("hello".getBytes());
+        File sidecar = new File(written + ".json");
+        assertThat(sidecar).isFile();
+        assertThat(Files.readAllBytes(sidecar.toPath()))
+                .isEqualTo(new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
+    }
+
+    @Test
+    public void test_write_from_tika_input_stream_creates_raw_and_sidecar_and_resets() throws Exception {
+        Path root = tmp.getRoot().toPath();
+        Path source = tmp.newFile("stream.bin").toPath();
+        Files.write(source, "streamed".getBytes());
+        Metadata metadata = metadataWithName("stream.bin");
+
+        try (TikaInputStream tis = TikaInputStream.get(source)) {
+            File written = EmbeddedArtifactWriter.write(root, ID, metadata, tis);
+            assertThat(Files.readAllBytes(written.toPath())).isEqualTo("streamed".getBytes());
+            assertThat(new File(written + ".json")).isFile();
+            // reset() was called: the stream is readable again from the start.
+            assertThat(tis.read()).isEqualTo((int) 's');
+        }
+    }
+
+    @Test
+    public void test_write_overwrites_existing_payload() throws Exception {
+        Path root = tmp.getRoot().toPath();
+        Path first = tmp.newFile("first.bin").toPath();
+        Files.write(first, "one".getBytes());
+        Path second = tmp.newFile("second.bin").toPath();
+        Files.write(second, "twotwo".getBytes());
+        Metadata metadata = metadataWithName("x");
+
+        EmbeddedArtifactWriter.write(root, ID, metadata, first);
+        File written = EmbeddedArtifactWriter.write(root, ID, metadata, second);
+
+        assertThat(Files.readAllBytes(written.toPath())).isEqualTo("twotwo".getBytes());
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
@@ -500,6 +500,28 @@ public class ExtractorTest {
 	}
 
 	@Test
+	public void testEmbeddedWithDuplicatesFlatWhenNotContentAddressable() throws Exception {
+        //GIVEN: the CLI default (bare PathIdentifier via new Extractor()), under which embed ids are
+        // filesystem paths, not content digests. --embedOutput must keep its legacy flat, hash-keyed dump.
+		Extractor extractor = aBasicExtractor();
+		extractor.disableOcr();
+		Path embedsRoot = folder.newFolder("embeds-flat").toPath();
+		extractor.setEmbedOutputPath(embedsRoot);
+		/* embedded_with_duplicate.tgz: two byte-identical images collapse to one file under the flat
+		   content-hash layout, so 6 unique files are written (the historical behavior). */
+        //WHEN
+		TikaDocument tikaDocument = extractDocument(extractor, "/documents/embedded_with_duplicate.tgz");
+		FileSpewer fileSpewer = new FileSpewer(new FieldNames());
+		fileSpewer.setOutputDirectory(folder.getRoot().toPath());
+		fileSpewer.write(tikaDocument);
+        //THEN: flat files named by content hash directly under embedsRoot, deduped to 6, no xx/yy nesting.
+		assertThat(embedsRoot.toFile().listFiles()).hasSize(6);
+		try (Stream<Path> walk = Files.walk(embedsRoot)) {
+			assertThat(walk.anyMatch(p -> p.getFileName().toString().equals("raw"))).isFalse();
+		}
+	}
+
+	@Test
 	public void testPageIndicesExtractionForPdf() throws Exception {
         //GIVEN
         String text;

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
@@ -13,6 +13,7 @@ import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.document.EmbeddedTikaDocument;
 import org.icij.extract.document.PathIdentifier;
 import org.icij.extract.document.TikaDocument;
+import org.icij.extract.document.TikaDocumentSource;
 import org.icij.extract.ocr.Tess4JOCRConfigAdapter;
 import org.icij.extract.ocr.Tess4JOCRParser;
 import org.icij.spewer.FieldNames;
@@ -497,6 +498,41 @@ public class ExtractorTest {
 			rawFilesOnDisk = walk.filter(p -> p.getFileName().toString().equals("raw")).count();
 		}
 		assertThat(toIntExact(rawFilesOnDisk)).isEqualTo((int) embedIds.stream().distinct().count());
+	}
+
+	@Test
+	public void testEmbedSpawnerWriteIsReadableByEmbeddedDocumentExtractor() throws Exception {
+        //GIVEN
+        // NOTE: aBasicExtractor() cannot be used here either, for the same reason as
+        // testEmbeddedWithDuplicates() above: under a bare PathIdentifier every embed's getId()
+        // collapses to the root document's path, so embeds are written with the legacy flat
+        // layout, not the nested xx/yy/<id>/raw layout, and getEmbeddedPath would never resolve
+        // to a file. Use the DigestIdentifier-configured factory instead.
+        DocumentFactory documentFactory = new DocumentFactory().configure();
+        Extractor extractor = new Extractor(documentFactory);
+        extractor.disableOcr();
+        Path artifactDir = folder.newFolder("artifacts").toPath();
+        extractor.setEmbedOutputPath(artifactDir);
+
+        //WHEN: EmbedSpawner writes each embed's raw bytes under artifactDir during extraction.
+        TikaDocument tikaDocument = extractDocument(extractor, "/documents/embedded_with_duplicate.tgz");
+        FileSpewer fileSpewer = new FileSpewer(new FieldNames());
+        fileSpewer.setOutputDirectory(folder.getRoot().toPath());
+        fileSpewer.write(tikaDocument);
+
+        // Pick a first-level embed that actually has bytes on disk.
+        EmbeddedTikaDocument embed = tikaDocument.getEmbeds().stream()
+                .filter(e -> EmbeddedDocumentExtractor.getEmbeddedPath(artifactDir, e.getId()).toFile().isFile())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no first-level embed was written to the artifact dir"));
+        byte[] expected = Files.readAllBytes(EmbeddedDocumentExtractor.getEmbeddedPath(artifactDir, embed.getId()));
+
+        //THEN: the on-demand reader (datashare's serving path) resolves the same id to the same bytes,
+        // via EmbeddedDocumentExtractor.extract's cache-hit branch (no re-parse needed).
+        EmbeddedDocumentExtractor reader = new EmbeddedDocumentExtractor(
+                new UpdatableDigester("prj", "SHA-256"), artifactDir);
+        TikaDocumentSource source = reader.extract(tikaDocument, embed.getId());
+        assertThat(source.getContent()).isEqualTo(expected);
 	}
 
 	@Test

--- a/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/ExtractorTest.java
@@ -451,18 +451,24 @@ public class ExtractorTest {
 	@Test
 	public void testEmbeddedWithDuplicates() throws Exception {
         //GIVEN
-        Extractor extractor = aBasicExtractor();
+        // NOTE: aBasicExtractor() cannot be used here. It builds its DocumentFactory with a bare
+        // PathIdentifier (see Extractor()), and EmbeddedTikaDocument inherits its parent's `path`
+        // unchanged, so under PathIdentifier every embed's getId() collapses to the SAME value (the
+        // root document's absolute file path), which breaks both id-uniqueness and the xx/yy sharding
+        // in ArtifactUtils.getEmbeddedPath. Use the DigestIdentifier-configured factory instead (same
+        // pattern as testDocumentHasNoLanguage() above), which is what production (DocumentFactory's
+        // own configure()/CLI default) actually uses and matches the id formula documented below.
+        DocumentFactory documentFactory = new DocumentFactory().configure();
+        Extractor extractor = new Extractor(documentFactory);
 		extractor.disableOcr();
-		extractor.setEmbedOutputPath(folder.newFolder("embeds").toPath());
+		Path embedsRoot = folder.newFolder("embeds").toPath();
+		extractor.setEmbedOutputPath(embedsRoot);
 		/*
-		embedded_with_duplicate.tgz :
-			2020-09-11 08:56 level1/
-			2020-09-08 15:10 level1/one_pixel_level1.jpg
-			2020-09-08 15:11 level1/file.txt          |
-			2020-09-08 15:11 level1/level2.tgz        |
-			2020-09-08 15:10 		level2/          same
-			2020-09-08 15:10 		level2/file.txt   |
-			2020-09-08 15:10 		level2/one_pixel.jpg
+		embedded_with_duplicate.tgz contains a nested tree in which two images
+		(level1/one_pixel_level1.jpg and level1/level2/one_pixel.jpg) are byte-identical.
+		Keyed by embed id (parent + relationship + name + file digest) they are DISTINCT
+		documents, so each gets its own raw payload -- unlike the old flat, hash-keyed layout
+		that collapsed them into one file.
 		 */
         //WHEN
 		TikaDocument tikaDocument = extractDocument(extractor, "/documents/embedded_with_duplicate.tgz");
@@ -470,15 +476,27 @@ public class ExtractorTest {
 		fileSpewer.setOutputDirectory(folder.getRoot().toPath());
 		fileSpewer.write(tikaDocument);
 
-		/* should find
-		 hash(embedded_with_duplicate.tgz)
-		 hash(embedded_with_duplicate.tar)
-		 hash(level1/file.txt)
-		 hash(level1/level2.tgz)
-		 hash(level1/level2/file.txt)
-		 hash(level1/one_pixel_level1.jpg) = hash(level1/level2/one_pixel.jpg) */
         //THEN
-		assertThat(folder.getRoot().toPath().resolve("embeds").toFile().listFiles()).hasSize(6);
+		// Collect every embed id in the tree (skip the root; only embeds are written).
+		List<String> embedIds = new ArrayList<>();
+		tikaDocument.apply(doc -> {
+			if (doc != tikaDocument) {
+				embedIds.add(doc.getId());
+			}
+		});
+		// Every embed's bytes live at its id-keyed raw path, with a raw.json sidecar next to it.
+		for (String id : embedIds) {
+			Path raw = EmbeddedDocumentExtractor.getEmbeddedPath(embedsRoot, id);
+			assertThat(raw.toFile()).isFile();
+			assertThat(raw.resolveSibling("raw.json").toFile()).isFile();
+		}
+		// The number of raw payloads on disk equals the number of distinct embed ids
+		// (the two identical images are distinct ids, so they are NOT deduplicated).
+		long rawFilesOnDisk;
+		try (Stream<Path> walk = Files.walk(embedsRoot)) {
+			rawFilesOnDisk = walk.filter(p -> p.getFileName().toString().equals("raw")).count();
+		}
+		assertThat(toIntExact(rawFilesOnDisk)).isEqualTo((int) embedIds.stream().distinct().count());
 	}
 
 	@Test


### PR DESCRIPTION
Unifies where embedded "raw" artifacts are written so the streaming/INDEX-time writer (`EmbedSpawner`) and the on-demand/ARTIFACT-stage writer (`EmbeddedDocumentExtractor`) agree on the content-addressed layout (`artifactPath/xx/yy/<id>/raw` + `raw.json`), keyed by the embed id. This lets datashare's INDEX-produced manifests and its `SourceExtractor` resolve to the same bytes.

- feat: add `EmbeddedArtifactWriter`, the single owner of the raw/raw.json layout
- refactor: route `EmbeddedDocumentExtractor` through `EmbeddedArtifactWriter`
- feat: `EmbedSpawner` writes raw/raw.json keyed by embed id instead of the flat hash file
- feat: keep the legacy flat dump for non-content-addressable ids (preserves extract-cli `--embedOutput` under `PathIdentifier`)
- test: cover both layouts and that `EmbedSpawner` output is readable by `EmbeddedDocumentExtractor`
