### PR TITLE
fix(artifacts): embedded-document extraction reliability (FD leak, OST parser, atomic writes, id parity)

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbedParser.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbedParser.java
@@ -23,6 +23,7 @@ import org.xml.sax.helpers.AttributesImpl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 
 import static org.apache.tika.sax.XHTMLContentHandler.XHTML;
 
@@ -78,6 +79,18 @@ public class EmbedParser extends ParsingEmbeddedDocumentExtractor {
 	// supplied metadata (which, on that path, is the discardable clone), never the shared object.
 	void delegateParsing(final InputStream input, final ContentHandler handler, final Metadata metadata,
 	                     final ParseContext parseContext) throws IOException, SAXException {
+		// Cooperative cancellation point, mirroring EmbedSpawner.parseEmbedded: this method is the
+		// one place every embed-boundary parse (serial spawn, deferred OCR AND the ARTIFACT/download
+		// retrieval walk built on this class) funnels through to actually delegate a parse. The
+		// retrieval path has no per-entry timeout of its own, so without this check a pathological
+		// entry (quadratic parser, huge/malformed container) ignores ArtifactTask.cancel()'s
+		// future.cancel(true) interrupt and hangs the worker. Check before any work (outside the
+		// try, so it can never be caught/downgraded by the TikaException handling below) so the walk
+		// aborts between entries; leave the interrupt flag set so every subsequent embed also aborts.
+		if (Thread.currentThread().isInterrupted()) {
+			throw new InterruptedIOException("embedded extraction cancelled (thread interrupted): "
+					+ metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY));
+		}
 		try (final TikaInputStream tis = TikaInputStream.get(CloseShieldInputStream.wrap(input))) {
 			if (input instanceof TikaInputStream) {
 				final Object container = ((TikaInputStream) input).getOpenContainer();

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedArtifactWriter.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedArtifactWriter.java
@@ -1,12 +1,10 @@
 package org.icij.extract.extractor;
 
-import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.icij.spewer.MetadataTransformer;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
@@ -50,42 +48,6 @@ class EmbeddedArtifactWriter {
             Files.deleteIfExists(rawTmp);
             Files.deleteIfExists(jsonTmp);
         }
-        return embedded.toFile();
-    }
-
-    // Stream the embed bytes into the raw payload (8K buffer) via the same temp-then-atomic-move
-    // as the Path overload, write the raw.json sidecar, then reset the stream so the caller can
-    // reuse it. Mirrors EmbeddedDocumentExtractor's prior writeFile(tis).
-    // Marks the stream itself before reading so reset() below is always valid, regardless of whether
-    // the caller already marked it. Callers pass a file-backed TikaInputStream (spooled to disk), for
-    // which mark/reset re-seeks the file and the readlimit is ignored; the 0 readlimit is therefore safe
-    // here and would only be a concern for a purely in-memory, non-file-backed stream, which never reaches
-    // this overload (EmbeddedDocumentExtractor's callers spool first; EmbedSpawner uses the Path overload).
-    static File write(final Path artifactPath, final String id, final Metadata metadata, final TikaInputStream tis) throws IOException {
-        final Path embedded = rawPath(artifactPath, id);
-        final Path dir = embedded.getParent();
-        Files.createDirectories(dir);
-
-        tis.mark(0);
-        final Path rawTmp = Files.createTempFile(dir, "raw", ".tmp");
-        final Path jsonTmp = Files.createTempFile(dir, "raw", ".json.tmp");
-        try {
-            try (OutputStream embeddedOutputStream = Files.newOutputStream(rawTmp)) {
-                int nbTmpBytesRead;
-                for (byte[] tmp = new byte[8192]; (nbTmpBytesRead = tis.read(tmp)) > 0; ) {
-                    embeddedOutputStream.write(tmp, 0, nbTmpBytesRead);
-                }
-            }
-            Files.write(jsonTmp, new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
-            atomicMove(rawTmp, embedded);
-            atomicMove(jsonTmp, sidecarOf(embedded));
-        } finally {
-            Files.deleteIfExists(rawTmp);
-            Files.deleteIfExists(jsonTmp);
-        }
-        // Only reached once the new bytes are fully written and moved into place; on any failure
-        // above, the exception propagates and the stream is left unreset (same as before this fix).
-        tis.reset();
         return embedded.toFile();
     }
 

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedArtifactWriter.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedArtifactWriter.java
@@ -5,12 +5,12 @@ import org.apache.tika.metadata.Metadata;
 import org.icij.spewer.MetadataTransformer;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 // Single owner of the content-addressed raw layout for an embedded document's bytes.
@@ -28,37 +28,80 @@ class EmbeddedArtifactWriter {
         return ArtifactUtils.getEmbeddedPath(artifactPath, id).resolve("raw");
     }
 
-    // Copy already-spooled bytes into the raw payload (overwriting) and write the raw.json sidecar.
+    // Copy already-spooled bytes into the raw payload and write the raw.json sidecar, both via
+    // write-to-temp-then-atomic-move so concurrent writers (e.g. two ARTIFACT workers
+    // re-extracting the same root under parallelism > 1) never race on the final path: ids are
+    // content-addressed, so concurrent writers always write identical bytes and atomic
+    // last-writer-wins is correct. No reader can ever observe a partial raw or sidecar, and a
+    // crash mid-write leaves only an orphaned temp file, never a truncated cache entry.
     static File write(final Path artifactPath, final String id, final Metadata metadata, final Path source) throws IOException {
-        final File embedded = rawPath(artifactPath, id).toFile();
-        Files.createDirectories(Paths.get(embedded.getParent()));
-        Files.copy(source, embedded.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        try (FileOutputStream metadataOutputStream = new FileOutputStream(embedded + ".json")) {
-            metadataOutputStream.write(new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
+        final Path embedded = rawPath(artifactPath, id);
+        final Path dir = embedded.getParent();
+        Files.createDirectories(dir);
+
+        final Path rawTmp = Files.createTempFile(dir, "raw", ".tmp");
+        final Path jsonTmp = Files.createTempFile(dir, "raw", ".json.tmp");
+        try {
+            Files.copy(source, rawTmp, StandardCopyOption.REPLACE_EXISTING);
+            Files.write(jsonTmp, new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
+            atomicMove(rawTmp, embedded);
+            atomicMove(jsonTmp, sidecarOf(embedded));
+        } finally {
+            Files.deleteIfExists(rawTmp);
+            Files.deleteIfExists(jsonTmp);
         }
-        return embedded;
+        return embedded.toFile();
     }
 
-    // Stream the embed bytes into the raw payload (8K buffer) and write the raw.json sidecar, then
-    // reset the stream so the caller can reuse it. Mirrors EmbeddedDocumentExtractor's prior writeFile(tis).
+    // Stream the embed bytes into the raw payload (8K buffer) via the same temp-then-atomic-move
+    // as the Path overload, write the raw.json sidecar, then reset the stream so the caller can
+    // reuse it. Mirrors EmbeddedDocumentExtractor's prior writeFile(tis).
     // Marks the stream itself before reading so reset() below is always valid, regardless of whether
     // the caller already marked it. Callers pass a file-backed TikaInputStream (spooled to disk), for
     // which mark/reset re-seeks the file and the readlimit is ignored; the 0 readlimit is therefore safe
     // here and would only be a concern for a purely in-memory, non-file-backed stream, which never reaches
     // this overload (EmbeddedDocumentExtractor's callers spool first; EmbedSpawner uses the Path overload).
     static File write(final Path artifactPath, final String id, final Metadata metadata, final TikaInputStream tis) throws IOException {
-        final File embedded = rawPath(artifactPath, id).toFile();
-        Files.createDirectories(Paths.get(embedded.getParent()));
+        final Path embedded = rawPath(artifactPath, id);
+        final Path dir = embedded.getParent();
+        Files.createDirectories(dir);
+
         tis.mark(0);
-        try (FileOutputStream embeddedOutputStream = new FileOutputStream(embedded);
-             FileOutputStream metadataOutputStream = new FileOutputStream(embedded + ".json")) {
-            int nbTmpBytesRead;
-            for (byte[] tmp = new byte[8192]; (nbTmpBytesRead = tis.read(tmp)) > 0; ) {
-                embeddedOutputStream.write(tmp, 0, nbTmpBytesRead);
+        final Path rawTmp = Files.createTempFile(dir, "raw", ".tmp");
+        final Path jsonTmp = Files.createTempFile(dir, "raw", ".json.tmp");
+        try {
+            try (OutputStream embeddedOutputStream = Files.newOutputStream(rawTmp)) {
+                int nbTmpBytesRead;
+                for (byte[] tmp = new byte[8192]; (nbTmpBytesRead = tis.read(tmp)) > 0; ) {
+                    embeddedOutputStream.write(tmp, 0, nbTmpBytesRead);
+                }
             }
-            metadataOutputStream.write(new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
+            Files.write(jsonTmp, new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
+            atomicMove(rawTmp, embedded);
+            atomicMove(jsonTmp, sidecarOf(embedded));
+        } finally {
+            Files.deleteIfExists(rawTmp);
+            Files.deleteIfExists(jsonTmp);
         }
+        // Only reached once the new bytes are fully written and moved into place; on any failure
+        // above, the exception propagates and the stream is left unreset (same as before this fix).
         tis.reset();
-        return embedded;
+        return embedded.toFile();
+    }
+
+    private static Path sidecarOf(Path embedded) {
+        return embedded.resolveSibling(embedded.getFileName() + ".json");
+    }
+
+    // Moves the temp file into place atomically (same directory as the target, so always the
+    // same filesystem -- ATOMIC_MOVE applies). Falls back to a plain replace-existing move on the
+    // rare filesystem that doesn't support atomic rename; still far better than the in-place
+    // copy/truncate this replaces, just without the atomicity guarantee.
+    private static void atomicMove(final Path tmp, final Path target) throws IOException {
+        try {
+            Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
     }
 }

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -20,6 +20,8 @@ import org.icij.extract.document.TikaDocument;
 import org.icij.extract.document.TikaDocumentSource;
 import org.icij.extract.parser.ResilientOutlookPSTParser;
 import org.icij.spewer.MetadataTransformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
@@ -34,6 +36,7 @@ import java.util.function.Supplier;
 import static java.util.Optional.ofNullable;
 
 public class EmbeddedDocumentExtractor {
+    private static final Logger logger = LoggerFactory.getLogger(EmbeddedDocumentExtractor.class);
     private final Parser parser;
     private final DigestingParser.Digester digester;
     private final String algorithm;
@@ -97,7 +100,14 @@ public class EmbeddedDocumentExtractor {
         if (artifactPath != null) {
             File cachedFile = getEmbeddedPath(artifactPath, embeddedDocumentDigest).toFile();
             if (cachedFile.exists()) {
-                return new TikaDocumentSource(MetadataTransformer.loadMetadata(new File(cachedFile + ".json")), DigestEmbeddedDocumentFileExtractor.getFileInputStream(cachedFile));
+                try {
+                    return new TikaDocumentSource(MetadataTransformer.loadMetadata(new File(cachedFile + ".json")), DigestEmbeddedDocumentFileExtractor.getFileInputStream(cachedFile));
+                } catch (IOException e) {
+                    // N2: a missing/corrupt sidecar (partial write, crash, format drift) must not be
+                    // a permanent failure -- the source is re-derivable from the root document, so
+                    // treat this as a cache miss and fall through to the live-parse path below.
+                    logger.debug("cache read failed for embedded document <{}>; falling back to live parse", embeddedDocumentDigest, e);
+                }
             }
         }
         ParseContext context = newParseContext();

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -12,11 +12,13 @@ import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.DigestingParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
+import org.apache.tika.parser.microsoft.pst.OutlookPSTParser;
 import org.apache.tika.parser.ocr.TesseractOCRConfig;
 import org.apache.tika.sax.BodyContentHandler;
 import org.icij.extract.document.EmbeddedTikaDocument;
 import org.icij.extract.document.TikaDocument;
 import org.icij.extract.document.TikaDocumentSource;
+import org.icij.extract.parser.ResilientOutlookPSTParser;
 import org.icij.spewer.MetadataTransformer;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -52,7 +54,7 @@ public class EmbeddedDocumentExtractor {
     }
 
     public EmbeddedDocumentExtractor(final DigestingParser.Digester digester, String algorithm, Path artifactPath, boolean ocr) {
-        this.parser = new DigestingParser(ocr ? new AutoDetectParser() : createParserWithoutOCR(), digester, false);
+        this.parser = new DigestingParser(ocr ? withResilientPstParser() : createParserWithoutOCR(), digester, false);
         this.digester = digester;
         this.artifactPath = artifactPath;
         this.algorithm = algorithm;
@@ -121,6 +123,13 @@ public class EmbeddedDocumentExtractor {
 
     static Path getEmbeddedPath(Path artifactPath, String digest) {
         return EmbeddedArtifactWriter.rawPath(artifactPath, digest);
+    }
+
+    // Test-support only: exposes the constructed parser so a test can walk its sub-parser
+    // tree and assert which concrete parsers are wired in (e.g. resilient vs stock Outlook
+    // PST parser), without re-deriving the construction logic in the test itself.
+    Parser getParser() {
+        return parser;
     }
 
     private static abstract class DigestEmbeddedDocumentExtractor extends EmbedParser {
@@ -343,15 +352,35 @@ public class EmbeddedDocumentExtractor {
 
     private Parser createParserWithoutOCR() {
         try {
-            return new AutoDetectParser(new TikaConfig(new ByteArrayInputStream((
+            TikaConfig config = new TikaConfig(new ByteArrayInputStream((
                     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                             "<properties><parsers><parser class=\"org.apache.tika.parser.DefaultParser\">" +
                             "<parser-exclude class=\"org.apache.tika.parser.ocr.TesseractOCRParser\"/>" +
-                            "</parser></parsers></properties>").getBytes())));
+                            "</parser></parsers></properties>").getBytes()));
+            return new AutoDetectParser(config.getDetector(), withResilientPstParser(config.getParser()));
         } catch (TikaException | IOException | SAXException e) {
             throw new RuntimeException(e);
         }
     }
+
+    // Builds the default (OCR-enabled) base parser, with Tika's stock OutlookPSTParser swapped
+    // for the resilient one -- the same swap Extractor applies at INDEX time (see
+    // Extractor.replaceParser(OutlookPSTParser.class, ...)). Without it, ARTIFACT/download
+    // re-extraction from a PST/OST uses the stock parser and fails (e.g. "OST 2013 support not
+    // added yet") even though INDEX succeeded.
+    private Parser withResilientPstParser() {
+        return new AutoDetectParser(withResilientPstParser(TikaConfig.getDefaultConfig().getParser()));
+    }
+
+    // Applies the same swap to an already-built (non-AutoDetectParser) composite, such as
+    // TikaConfig's DefaultParser. Must run on this inner composite, not on a constructed
+    // AutoDetectParser: replaceParser flattens whatever composite it's given into a plain
+    // CompositeParser, so applying it to an AutoDetectParser instance directly would discard its
+    // detector/config wiring and break MIME-type auto-detection for every format, not just PST.
+    private static Parser withResilientPstParser(Parser configParser) {
+        return Extractor.replaceParser(configParser, OutlookPSTParser.class, p -> new ResilientOutlookPSTParser());
+    }
+
     public static class ContentNotFoundException extends NullPointerException {
         public ContentNotFoundException(String rootId, String embedId) {
             super(String.format("<%s> embedded document not found in root document <%s>", embedId, rootId));

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -167,6 +167,11 @@ public class EmbeddedDocumentExtractor {
         @Override
         void delegateParsing(InputStream stream, ContentHandler handler, Metadata metadata) throws IOException, SAXException {
             EmbeddedTikaDocument embed = this.documentStack.getLast().addEmbed(metadata);
+            // Push right away, before any of the digesting/callback work below that can throw
+            // (e.g. a per-message digest failure in a resilient walk). The matching finally
+            // always pops exactly what this invocation pushed, so a failure here can never
+            // underflow the stack and corrupt the walk for the next sibling embed.
+            this.documentStack.add(embed);
             try (final TikaInputStream tis = TikaInputStream.get(CloseShieldInputStream.wrap(stream))) {
                 if (stream instanceof TikaInputStream) {
                     final Object container = ((TikaInputStream) stream).getOpenContainer();
@@ -197,7 +202,6 @@ public class EmbeddedDocumentExtractor {
                     // super.delegateParsing below triggers DigestingParser which overwrites it.
                     String digest = embed.getId();
                     boolean found = documentCallback(metadata, digest, spooled);
-                    this.documentStack.add(embed);
                     // Once the target embed is captured, skip recursing into it: its content is
                     // already saved and recursion would parse/OCR it needlessly. Combined with
                     // shouldParseEmbedded() returning false afterwards, this stops the walk early.
@@ -237,7 +241,6 @@ public class EmbeddedDocumentExtractor {
                 // and break ID lookups for any child embeds that reference this embed as parent.
                 String digest = embed.getId();
                 boolean found = documentCallback(metadata, digest, tis);
-                this.documentStack.add(embed);
                 if (!found) {
                     super.delegateParsing(tis, handler, metadata);
                 }

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -161,7 +161,6 @@ public class EmbeddedDocumentExtractor {
             this.documentTikaVersion = document.getTikaVersion();
         }
 
-        protected abstract boolean documentCallback(Metadata metadata, String digest, TikaInputStream tis) throws IOException;
         protected abstract boolean documentCallback(Metadata metadata, String digest, Path spooled) throws IOException;
 
         @Override
@@ -256,10 +255,6 @@ public class EmbeddedDocumentExtractor {
             }
         }
 
-        protected File writeFile(Metadata metadata, String digest, TikaInputStream tis) throws IOException {
-            return EmbeddedArtifactWriter.write(this.artifactPath, digest, metadata, tis);
-        }
-
         protected File writeFile(Metadata metadata, String digest, Path source) throws IOException {
             return EmbeddedArtifactWriter.write(this.artifactPath, digest, metadata, source);
         }
@@ -268,12 +263,6 @@ public class EmbeddedDocumentExtractor {
     static class DigestAllEmbeddedDocumentExtractor extends DigestEmbeddedDocumentExtractor {
         DigestAllEmbeddedDocumentExtractor(TikaDocument document, ParseContext context, DigestingParser.Digester digester, String algorithm, Path artifactPath) {
             super(document, context, digester, algorithm, artifactPath);
-        }
-
-        @Override
-        protected boolean documentCallback(Metadata metadata, String digest, TikaInputStream tis) throws IOException {
-            writeFile(metadata, digest, tis);
-            return false;
         }
 
         @Override
@@ -299,21 +288,6 @@ public class EmbeddedDocumentExtractor {
             // OCR-heavy) entries instead of walking the whole archive. This hook is the clean
             // way to short-circuit: it needs no exception and works the same for every container.
             return document == null && super.shouldParseEmbedded(metadata);
-        }
-
-        @Override
-        protected boolean documentCallback(Metadata metadata, String digest, TikaInputStream tis) throws IOException {
-            if (digestToFind.equals(digest)) {
-                Supplier<InputStream> inputStreamSupplier = getInputStreamSupplier(metadata, digest, tis);
-                this.document = new TikaDocumentSource(metadata, inputStreamSupplier);
-                return true;
-            }
-            return false;
-        }
-
-        protected Supplier<InputStream> getInputStreamSupplier(Metadata metadata, String digest, TikaInputStream tis) throws IOException {
-            File embedded = writeFile(metadata, digest, tis);
-            return getFileInputStream(embedded);
         }
 
         @Override
@@ -351,16 +325,6 @@ public class EmbeddedDocumentExtractor {
     static class DigestEmbeddedDocumentMemoryExtractor extends DigestEmbeddedDocumentFileExtractor {
         DigestEmbeddedDocumentMemoryExtractor(TikaDocument rootDocument, String digestToFind, ParseContext context, DigestingParser.Digester digester, String algorithm) {
             super(rootDocument, digestToFind, context, digester, algorithm, null);
-        }
-
-        @Override
-        protected Supplier<InputStream> getInputStreamSupplier(Metadata metadata, String digest, TikaInputStream tis) throws IOException {
-            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            int nbTmpBytesRead;
-            for (byte[] tmp = new byte[8192]; (nbTmpBytesRead = tis.read(tmp)) > 0; ) {
-                buffer.write(tmp, 0, nbTmpBytesRead); // uses the memory
-            }
-            return () -> new ByteArrayInputStream(buffer.toByteArray());
         }
 
         @Override

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -198,21 +198,28 @@ public class EmbeddedDocumentExtractor {
                     try (TikaInputStream digestStream = TikaInputStream.get(spooled)) {
                         digester.digest(digestStream, metadata, context);
                     }
-                    // Cache the embed id now while metadata still holds the correct hash:
-                    // super.delegateParsing below triggers DigestingParser which overwrites it.
-                    String digest = embed.getId();
-                    boolean found = documentCallback(metadata, digest, spooled);
-                    // Once the target embed is captured, skip recursing into it: its content is
-                    // already saved and recursion would parse/OCR it needlessly. Combined with
-                    // shouldParseEmbedded() returning false afterwards, this stops the walk early.
-                    if (!found) {
-                        try (TikaInputStream parseStream = TikaInputStream.get(spooled)) {
-                            super.delegateParsing(parseStream, handler, metadata);
-                        }
+                    // Parse FIRST, then freeze the id and write -- mirroring EmbedSpawner
+                    // (parse-then-write). The sub-parse (e.g. PSTMailItemParser) enriches this
+                    // embed's metadata with EMBEDDED_RELATIONSHIP_ID / resourceName / Content-Type,
+                    // all of which DigestIdentifier folds into the id. Freezing the id BEFORE the
+                    // sub-parse (as this used to) dropped those fields, so retrieval wrote bytes
+                    // under ids the index never produced (OST-2). This embed's own content hash is
+                    // set above and is NOT overwritten by the recursion (each child digests into its
+                    // OWN metadata), so the frozen id = SHA(thisEmbedHash || parentId || relId ||
+                    // name) matches the id EmbedSpawner froze after the same sub-parse at index time.
+                    try (TikaInputStream parseStream = TikaInputStream.get(spooled)) {
+                        super.delegateParsing(parseStream, handler, metadata);
                     }
+                    String digest = embed.getId();
+                    documentCallback(metadata, digest, spooled);
                     return;
                 }
 
+                // Spool the entry to a temp file so its bytes survive the sub-parse below (which
+                // consumes the stream) and remain writable afterwards; mirrors EmbedSpawner, which
+                // spools via tis.getPath() before delegateParsing and writes the same file after.
+                // This also file-backs tis so the mark/reset digest below re-seeks the file.
+                final Path spooled = tis.getPath();
                 tis.mark(0); // Marking the position before resetting
                 if (shouldTranslate && !retroCompat) {
                     // Tika >= 3.3.0: hash the translated bytes so the digest matches the actual content
@@ -235,15 +242,15 @@ public class EmbeddedDocumentExtractor {
                     digester.digest(tis, metadata, context);
                 }
                 tis.reset();
-                // Force the embed ID to be cached now while metadata still holds the correct hash.
-                // super.delegateParsing below triggers DigestingParser which overwrites the hash in metadata;
-                // without pre-caching, lazy getId() on this embed would compute with the wrong hash
-                // and break ID lookups for any child embeds that reference this embed as parent.
+                // Parse FIRST, then freeze the id and write from the spooled bytes -- see the
+                // raw-branch note above. The sub-parse enriches EMBEDDED_RELATIONSHIP_ID /
+                // resourceName / Content-Type that DigestIdentifier folds into the id, so freezing
+                // the id after it makes retrieval ids match the index ids (OST-2). This embed's own
+                // content hash is set above and survives the recursion (children digest into their
+                // own metadata), so the composed id is unchanged from EmbedSpawner's.
+                super.delegateParsing(tis, handler, metadata);
                 String digest = embed.getId();
-                boolean found = documentCallback(metadata, digest, tis);
-                if (!found) {
-                    super.delegateParsing(tis, handler, metadata);
-                }
+                documentCallback(metadata, digest, spooled);
             } finally {
                 this.documentStack.removeLast();
             }

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -174,126 +174,159 @@ public class EmbeddedDocumentExtractor {
             // underflow the stack and corrupt the walk for the next sibling embed.
             this.documentStack.add(embed);
             try (final TikaInputStream tis = TikaInputStream.get(CloseShieldInputStream.wrap(stream))) {
-                if (stream instanceof TikaInputStream) {
-                    final Object container = ((TikaInputStream) stream).getOpenContainer();
+                // Hoisted so the failure handler below can reach the spooled bytes. Stays null until a
+                // successful tis.getPath() spool populates it: null therefore means "the read/spool
+                // itself failed and no bytes were ever captured" (the OST-2013 truncated by-value
+                // attachment case), while non-null means the real entry bytes exist on disk (a later
+                // sub-parse failure does not consume or delete them, since the parse reads a separate
+                // stream / tis stays open until the enclosing try-with-resources). This is the EmbedSpawner
+                // mirror: EmbedSpawner.writeEmbed writes tis.getPath() regardless of the parse outcome.
+                Path spooled = null;
+                try {
+                    if (stream instanceof TikaInputStream) {
+                        final Object container = ((TikaInputStream) stream).getOpenContainer();
 
-                    if (container != null) {
-                        tis.setOpenContainer(container);
+                        if (container != null) {
+                            tis.setOpenContainer(container);
+                        }
                     }
-                }
-                // this if/else is coming from DigestingParser since 3.3.0 to fix issues with Microsoft OLE docs
-                // see https://issues.apache.org/jira/browse/TIKA-4533
-                boolean shouldTranslate = embeddedStreamTranslator.shouldTranslate(tis, metadata);
-                boolean retroCompat = documentTikaVersion.compareTo(TIKA_3_2_3) <= 0;
+                    // this if/else is coming from DigestingParser since 3.3.0 to fix issues with Microsoft OLE docs
+                    // see https://issues.apache.org/jira/browse/TIKA-4533
+                    boolean shouldTranslate = embeddedStreamTranslator.shouldTranslate(tis, metadata);
+                    boolean retroCompat = documentTikaVersion.compareTo(TIKA_3_2_3) <= 0;
 
-                if (!(shouldTranslate && !retroCompat) && tis.getOpenContainer() == null) {
-                    // Raw (non-translated) entry from a container such as a zip/tar archive.
-                    // Spool the entry to a temp file once, then read independent file-backed
-                    // streams for the digest, the document callback and the recursive parse.
-                    // This avoids the in-memory mark()/reset() on the embedded stream, which
-                    // fails with "Resetting to invalid mark" (surfaced as TIKA-198 from
-                    // PackageParser) once an entry exceeds the digester's mark limit, and keeps
-                    // the per-entry parse memory bounded regardless of entry size. (The memory
-                    // extractor still buffers the single matched entry into a byte[] by design.)
-                    final Path spooled = tis.getPath();
-                    try (TikaInputStream digestStream = TikaInputStream.get(spooled)) {
-                        digester.digest(digestStream, metadata, context);
+                    if (!(shouldTranslate && !retroCompat) && tis.getOpenContainer() == null) {
+                        // Raw (non-translated) entry from a container such as a zip/tar archive.
+                        // Spool the entry to a temp file once, then read independent file-backed
+                        // streams for the digest, the document callback and the recursive parse.
+                        // This avoids the in-memory mark()/reset() on the embedded stream, which
+                        // fails with "Resetting to invalid mark" (surfaced as TIKA-198 from
+                        // PackageParser) once an entry exceeds the digester's mark limit, and keeps
+                        // the per-entry parse memory bounded regardless of entry size. (The memory
+                        // extractor still buffers the single matched entry into a byte[] by design.)
+                        spooled = tis.getPath();
+                        try (TikaInputStream digestStream = TikaInputStream.get(spooled)) {
+                            digester.digest(digestStream, metadata, context);
+                        }
+                        // Parse FIRST, then freeze the id and write -- mirroring EmbedSpawner
+                        // (parse-then-write). The sub-parse (e.g. PSTMailItemParser) enriches this
+                        // embed's metadata with EMBEDDED_RELATIONSHIP_ID / resourceName / Content-Type,
+                        // all of which DigestIdentifier folds into the id. Freezing the id BEFORE the
+                        // sub-parse (as this used to) dropped those fields, so retrieval wrote bytes
+                        // under ids the index never produced (OST-2). This embed's own content hash is
+                        // set above and is NOT overwritten by the recursion (each child digests into its
+                        // OWN metadata), so the frozen id = SHA(thisEmbedHash || parentId || relId ||
+                        // name) matches the id EmbedSpawner froze after the same sub-parse at index time.
+                        try (TikaInputStream parseStream = TikaInputStream.get(spooled)) {
+                            super.delegateParsing(parseStream, handler, metadata);
+                        }
+                        String digest = embed.getId();
+                        documentCallback(metadata, digest, spooled);
+                        return;
                     }
-                    // Parse FIRST, then freeze the id and write -- mirroring EmbedSpawner
-                    // (parse-then-write). The sub-parse (e.g. PSTMailItemParser) enriches this
-                    // embed's metadata with EMBEDDED_RELATIONSHIP_ID / resourceName / Content-Type,
-                    // all of which DigestIdentifier folds into the id. Freezing the id BEFORE the
-                    // sub-parse (as this used to) dropped those fields, so retrieval wrote bytes
-                    // under ids the index never produced (OST-2). This embed's own content hash is
-                    // set above and is NOT overwritten by the recursion (each child digests into its
-                    // OWN metadata), so the frozen id = SHA(thisEmbedHash || parentId || relId ||
-                    // name) matches the id EmbedSpawner froze after the same sub-parse at index time.
-                    try (TikaInputStream parseStream = TikaInputStream.get(spooled)) {
-                        super.delegateParsing(parseStream, handler, metadata);
+
+                    // Spool the entry to a temp file so its bytes survive the sub-parse below (which
+                    // consumes the stream) and remain writable afterwards; mirrors EmbedSpawner, which
+                    // spools via tis.getPath() before delegateParsing and writes the same file after.
+                    // This also file-backs tis so the mark/reset digest below re-seeks the file.
+                    spooled = tis.getPath();
+                    tis.mark(0); // Marking the position before resetting
+                    if (shouldTranslate && !retroCompat) {
+                        // Tika >= 3.3.0: hash the translated bytes so the digest matches the actual content
+                        Path translatedBytes;
+                        try (TemporaryResources tmp = new TemporaryResources()) {
+                            translatedBytes = tmp.createTempFile();
+                            if (tis.getOpenContainer() == null) {
+                                try (InputStream is = TikaInputStream.get(tis.getPath())) {
+                                    Files.copy(embeddedStreamTranslator.translate(is, metadata), translatedBytes, StandardCopyOption.REPLACE_EXISTING);
+                                }
+                            } else {
+                                Files.copy(embeddedStreamTranslator.translate(tis, metadata), translatedBytes, StandardCopyOption.REPLACE_EXISTING);
+                            }
+                            try (TikaInputStream translated = TikaInputStream.get(translatedBytes)) {
+                                digester.digest(translated, metadata, context);
+                            }
+                        }
+                    } else {
+                        // retro-compat (<= 3.2.3) or no translation needed: hash raw bytes
+                        digester.digest(tis, metadata, context);
                     }
+                    tis.reset();
+                    // Parse FIRST, then freeze the id and write from the spooled bytes -- see the
+                    // raw-branch note above. The sub-parse enriches EMBEDDED_RELATIONSHIP_ID /
+                    // resourceName / Content-Type that DigestIdentifier folds into the id, so freezing
+                    // the id after it makes retrieval ids match the index ids (OST-2). This embed's own
+                    // content hash is set above and survives the recursion (children digest into their
+                    // own metadata), so the composed id is unchanged from EmbedSpawner's.
+                    super.delegateParsing(tis, handler, metadata);
                     String digest = embed.getId();
                     documentCallback(metadata, digest, spooled);
-                    return;
-                }
-
-                // Spool the entry to a temp file so its bytes survive the sub-parse below (which
-                // consumes the stream) and remain writable afterwards; mirrors EmbedSpawner, which
-                // spools via tis.getPath() before delegateParsing and writes the same file after.
-                // This also file-backs tis so the mark/reset digest below re-seeks the file.
-                final Path spooled = tis.getPath();
-                tis.mark(0); // Marking the position before resetting
-                if (shouldTranslate && !retroCompat) {
-                    // Tika >= 3.3.0: hash the translated bytes so the digest matches the actual content
-                    Path translatedBytes;
-                    try (TemporaryResources tmp = new TemporaryResources()) {
-                        translatedBytes = tmp.createTempFile();
-                        if (tis.getOpenContainer() == null) {
-                            try (InputStream is = TikaInputStream.get(tis.getPath())) {
-                                Files.copy(embeddedStreamTranslator.translate(is, metadata), translatedBytes, StandardCopyOption.REPLACE_EXISTING);
-                            }
-                        } else {
-                            Files.copy(embeddedStreamTranslator.translate(tis, metadata), translatedBytes, StandardCopyOption.REPLACE_EXISTING);
-                        }
-                        try (TikaInputStream translated = TikaInputStream.get(translatedBytes)) {
-                            digester.digest(translated, metadata, context);
-                        }
+                } catch (final Exception e) {
+                    // Per-embed resilience, mirroring EmbedSpawner.spawnEmbedded's catch(Exception)+keep.
+                    // Two distinct failures land here and must be written differently so retrieval serves
+                    // the SAME bytes the index (EmbedSpawner) did under the SAME id:
+                    //   1. read/spool FAILED (spooled == null): no bytes were ever captured -- e.g. an
+                    //      OST-2013 multi-block TRUNCATED by-value attachment whose java-libpst read throws
+                    //      IndexOutOfBoundsException at com.pff.PSTNodeInputStream.read during tis.getPath().
+                    //      The digest never ran, so embed.getId() is the CONTENT-LESS id (DigestIdentifier
+                    //      null-hash path) -- the same id EmbedSpawner composed and polled. Write a zero-byte
+                    //      raw under it (faithful: there really are no bytes), else RawArtifact reports
+                    //      "produced no bytes" (F4b).
+                    //   2. spool+digest SUCCEEDED, then the sub-parse threw (spooled != null): the real
+                    //      entry bytes exist on disk and embed.getId() is now the CONTENT-FULL id (digest
+                    //      ran). EmbedSpawner.writeEmbed writes those real bytes regardless of the parse
+                    //      outcome, so write them here too -- writing an empty raw instead would silently
+                    //      serve an empty download for a document that actually has content.
+                    // The write happens only on the failure path (the try's own callback ran only on
+                    // success), so a healthy embed is never double-written and its real failure is never
+                    // hidden. Cancellation is never swallowed: an interrupt is rethrown without any write,
+                    // and rethrowing (unless the single-embed target was captured) preserves the
+                    // stack-balance (F4a) contract that the finally pop always matches the push above.
+                    if (e instanceof InterruptedIOException || Thread.currentThread().isInterrupted()) {
+                        throw e;
                     }
-                } else {
-                    // retro-compat (<= 3.2.3) or no translation needed: hash raw bytes
-                    digester.digest(tis, metadata, context);
+                    // tis is still open here (we are inside its try-with-resources), so a non-null
+                    // spooled path is still readable -- it is copied out by documentCallback before the
+                    // rethrow closes tis and deletes its temp resources.
+                    boolean targetCaptured = writeFailedEmbed(embed, metadata, e, spooled);
+                    // Single-embed retrieval: if this failing embed WAS the requested target, its
+                    // (possibly empty) source is now captured, so let getDocument() return it cleanly
+                    // instead of relying on Tika catching the rethrow before extract() unwinds. The
+                    // write-all extractor never captures a target (documentCallback returns false), so
+                    // it always rethrows and its per-embed isolation continues to the next sibling.
+                    if (!targetCaptured) {
+                        throw e;
+                    }
                 }
-                tis.reset();
-                // Parse FIRST, then freeze the id and write from the spooled bytes -- see the
-                // raw-branch note above. The sub-parse enriches EMBEDDED_RELATIONSHIP_ID /
-                // resourceName / Content-Type that DigestIdentifier folds into the id, so freezing
-                // the id after it makes retrieval ids match the index ids (OST-2). This embed's own
-                // content hash is set above and survives the recursion (children digest into their
-                // own metadata), so the composed id is unchanged from EmbedSpawner's.
-                super.delegateParsing(tis, handler, metadata);
-                String digest = embed.getId();
-                documentCallback(metadata, digest, spooled);
-            } catch (final Exception e) {
-                // Per-embed resilience, mirroring EmbedSpawner.spawnEmbedded's catch(Exception)+keep.
-                // Reading/parsing this embed's bytes failed -- e.g. an OST-2013 multi-block TRUNCATED
-                // by-value attachment whose java-libpst stream read throws IndexOutOfBoundsException at
-                // com.pff.PSTNodeInputStream.read while spooling above. The index (EmbedSpawner) kept
-                // such an embed and composed a CONTENT-LESS id for it (DigestIdentifier null-hash path),
-                // then polled that id. Here the same failure would otherwise propagate PAST the write,
-                // leaving that id with no raw -> RawArtifact "produced no bytes" (F4b). So write a
-                // zero-byte raw under the SAME id (embed.getId() with no content hash == the indexed
-                // id) before letting the exception propagate: Tika's per-attachment isolation then
-                // continues the walk to the next sibling exactly as it does today (only now the id
-                // resolves). The write happens only on the failure path (the try's own callback ran only
-                // on success), so a healthy embed is never double-written and its real failure is never
-                // hidden. Cancellation is never swallowed: an interrupt is rethrown without a spurious
-                // content-less write, and rethrowing here preserves the stack-balance (F4a) contract
-                // that the finally pop always matches the push above.
-                if (e instanceof InterruptedIOException || Thread.currentThread().isInterrupted()) {
-                    throw e;
-                }
-                writeContentLessEmbed(embed, metadata, e);
-                throw e;
             } finally {
                 this.documentStack.removeLast();
             }
         }
 
-        // Mirror EmbedSpawner's keep-on-failure for an embed whose bytes could not be read/parsed:
+        // Mirror EmbedSpawner's keep-on-failure for an embed that could not be fully read/parsed:
         // record the stream exception on the embed metadata (as EmbedSpawner does) and produce an
-        // id-addressed ZERO-BYTE artifact via the normal documentCallback, so the embed resolves to
-        // an empty raw under the same content-less id the index composed. Routes through the empty
-        // temp file + documentCallback so every subclass write path (write-all, single-embed file,
-        // in-memory) is reused unchanged, keeping the atomic-write contract (E-c) intact.
-        private void writeContentLessEmbed(final EmbeddedTikaDocument embed, final Metadata metadata,
-                                           final Exception cause) throws IOException {
+        // id-addressed artifact via the normal documentCallback, reusing every subclass write path
+        // (write-all, single-embed file, in-memory) unchanged so the atomic-write contract (E-c)
+        // holds. Returns documentCallback's result: true iff a single-embed extractor captured this
+        // embed as its requested target. When spooled bytes exist (spool+digest succeeded before the
+        // sub-parse failed) they are written under the content-full id; otherwise a zero-byte raw is
+        // written under the content-less id (the read/spool-failure case, hash == null).
+        private boolean writeFailedEmbed(final EmbeddedTikaDocument embed, final Metadata metadata,
+                                         final Exception cause, final Path spooled) throws IOException {
+            metadata.add(TikaCoreProperties.TIKA_META_EXCEPTION_EMBEDDED_STREAM,
+                    ExceptionUtils.getFilteredStackTrace(cause));
+            if (spooled != null && Files.isReadable(spooled)) {
+                logger.warn("Embedded document sub-parse failed after spooling; writing its real bytes: \"{}\" ({}) (in \"{}\").",
+                        metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY), metadata.get(Metadata.CONTENT_TYPE),
+                        documentStack.getFirst());
+                return documentCallback(metadata, embed.getId(), spooled);
+            }
             logger.warn("Unable to read embedded document bytes; writing content-less artifact: \"{}\" ({}) (in \"{}\").",
                     metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY), metadata.get(Metadata.CONTENT_TYPE),
                     documentStack.getFirst());
-            metadata.add(TikaCoreProperties.TIKA_META_EXCEPTION_EMBEDDED_STREAM,
-                    ExceptionUtils.getFilteredStackTrace(cause));
             final Path empty = Files.createTempFile("content-less-embed", ".raw");
             try {
-                documentCallback(metadata, embed.getId(), empty);
+                return documentCallback(metadata, embed.getId(), empty);
             } finally {
                 Files.deleteIfExists(empty);
             }

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -13,8 +13,10 @@ import org.apache.tika.parser.DigestingParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.microsoft.pst.OutlookPSTParser;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ocr.TesseractOCRConfig;
 import org.apache.tika.sax.BodyContentHandler;
+import org.apache.tika.utils.ExceptionUtils;
 import org.icij.extract.document.EmbeddedTikaDocument;
 import org.icij.extract.document.TikaDocument;
 import org.icij.extract.document.TikaDocumentSource;
@@ -250,8 +252,50 @@ public class EmbeddedDocumentExtractor {
                 super.delegateParsing(tis, handler, metadata);
                 String digest = embed.getId();
                 documentCallback(metadata, digest, spooled);
+            } catch (final Exception e) {
+                // Per-embed resilience, mirroring EmbedSpawner.spawnEmbedded's catch(Exception)+keep.
+                // Reading/parsing this embed's bytes failed -- e.g. an OST-2013 multi-block TRUNCATED
+                // by-value attachment whose java-libpst stream read throws IndexOutOfBoundsException at
+                // com.pff.PSTNodeInputStream.read while spooling above. The index (EmbedSpawner) kept
+                // such an embed and composed a CONTENT-LESS id for it (DigestIdentifier null-hash path),
+                // then polled that id. Here the same failure would otherwise propagate PAST the write,
+                // leaving that id with no raw -> RawArtifact "produced no bytes" (F4b). So write a
+                // zero-byte raw under the SAME id (embed.getId() with no content hash == the indexed
+                // id) before letting the exception propagate: Tika's per-attachment isolation then
+                // continues the walk to the next sibling exactly as it does today (only now the id
+                // resolves). The write happens only on the failure path (the try's own callback ran only
+                // on success), so a healthy embed is never double-written and its real failure is never
+                // hidden. Cancellation is never swallowed: an interrupt is rethrown without a spurious
+                // content-less write, and rethrowing here preserves the stack-balance (F4a) contract
+                // that the finally pop always matches the push above.
+                if (e instanceof InterruptedIOException || Thread.currentThread().isInterrupted()) {
+                    throw e;
+                }
+                writeContentLessEmbed(embed, metadata, e);
+                throw e;
             } finally {
                 this.documentStack.removeLast();
+            }
+        }
+
+        // Mirror EmbedSpawner's keep-on-failure for an embed whose bytes could not be read/parsed:
+        // record the stream exception on the embed metadata (as EmbedSpawner does) and produce an
+        // id-addressed ZERO-BYTE artifact via the normal documentCallback, so the embed resolves to
+        // an empty raw under the same content-less id the index composed. Routes through the empty
+        // temp file + documentCallback so every subclass write path (write-all, single-embed file,
+        // in-memory) is reused unchanged, keeping the atomic-write contract (E-c) intact.
+        private void writeContentLessEmbed(final EmbeddedTikaDocument embed, final Metadata metadata,
+                                           final Exception cause) throws IOException {
+            logger.warn("Unable to read embedded document bytes; writing content-less artifact: \"{}\" ({}) (in \"{}\").",
+                    metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY), metadata.get(Metadata.CONTENT_TYPE),
+                    documentStack.getFirst());
+            metadata.add(TikaCoreProperties.TIKA_META_EXCEPTION_EMBEDDED_STREAM,
+                    ExceptionUtils.getFilteredStackTrace(cause));
+            final Path empty = Files.createTempFile("content-less-embed", ".raw");
+            try {
+                documentCallback(metadata, embed.getId(), empty);
+            } finally {
+                Files.deleteIfExists(empty);
             }
         }
 

--- a/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
+++ b/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java
@@ -86,7 +86,9 @@ public class EmbeddedDocumentExtractor {
         DigestEmbeddedDocumentExtractor extractor = new DigestAllEmbeddedDocumentExtractor(document, context, digester, algorithm, artifactPath);
         context.set(org.apache.tika.extractor.EmbeddedDocumentExtractor.class, extractor);
 
-        parser.parse(new FileInputStream(document.getPath().toFile()), handler, document.getMetadata(), context);
+        try (InputStream in = Files.newInputStream(document.getPath())) {
+            parser.parse(in, handler, document.getMetadata(), context);
+        }
     }
 
     public TikaDocumentSource extract(final TikaDocument rootDocument, final String embeddedDocumentDigest) throws SAXException, TikaException, IOException {
@@ -102,7 +104,9 @@ public class EmbeddedDocumentExtractor {
         DigestEmbeddedDocumentFileExtractor extractor = getExtractor(rootDocument, embeddedDocumentDigest, context, artifactPath);
         context.set(org.apache.tika.extractor.EmbeddedDocumentExtractor.class, extractor);
 
-        parser.parse(new FileInputStream(rootDocument.getPath().toFile()), handler, rootDocument.getMetadata(), context);
+        try (InputStream in = Files.newInputStream(rootDocument.getPath())) {
+            parser.parse(in, handler, rootDocument.getMetadata(), context);
+        }
 
         return extractor.getDocument();
     }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbedParserCancellationTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbedParserCancellationTest.java
@@ -1,0 +1,119 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.AbstractParser;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.BodyContentHandler;
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.TikaDocument;
+import org.junit.Test;
+import org.xml.sax.ContentHandler;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.Fail.fail;
+
+/**
+ * {@link EmbedParser#delegateParsing} is the one place every embed-boundary parse funnels
+ * through: EmbedSpawner's serial and deferred-OCR spawn paths call it, and so does the
+ * ARTIFACT/download retrieval walk (EmbeddedDocumentExtractor, built directly on EmbedParser).
+ * Unlike {@link EmbedSpawner#parseEmbedded} (see {@link EmbedSpawnerCancellationTest}), it had no
+ * cooperative interrupt check of its own, so the retrieval path ignored Extractor's parse-timeout
+ * {@code future.cancel(true)} interrupt and could hang a worker on a pathological entry (a
+ * quadratic parser, a huge/malformed container, ...).
+ */
+public class EmbedParserCancellationTest {
+
+    private static TikaDocument root() {
+        return new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", Charset.defaultCharset()))
+                .create(Paths.get("/tmp/fake-root"));
+    }
+
+    /** A delegate parser that records how many entries it actually got asked to parse. */
+    private static class CountingParser extends AbstractParser {
+        final AtomicInteger invocations = new AtomicInteger();
+
+        @Override
+        public Set<MediaType> getSupportedTypes(final ParseContext context) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void parse(final InputStream stream, final ContentHandler handler,
+                          final Metadata metadata, final ParseContext context) {
+            invocations.incrementAndGet();
+        }
+    }
+
+    private static Metadata nonInline(final String name) {
+        final Metadata m = new Metadata();
+        m.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+        return m;
+    }
+
+    private static InputStream payload() {
+        return new ByteArrayInputStream("payload".getBytes(Charset.defaultCharset()));
+    }
+
+    @Test
+    public void testInterruptedDelegateParsingAbortsBeforeParsingTheEntry() throws Exception {
+        final CountingParser counting = new CountingParser();
+        final EmbedParser parser = new EmbedParser(root(), new ParseContext(), counting);
+
+        Thread.currentThread().interrupt(); // simulate future.cancel(true) on parse-timeout
+        boolean threw = false;
+        try {
+            parser.delegateParsing(payload(), new BodyContentHandler(), nonInline("attachment.bin"));
+        } catch (final InterruptedIOException expected) {
+            threw = true;
+            // The interrupt flag must stay set so every subsequent embed on this parse also aborts,
+            // even if a Tika container parser swallows an individual throw.
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted(); // clear so we don't poison the test-runner thread
+        }
+
+        assertThat(threw).isTrue();
+        // The entry's own content was never handed to the delegate parser: the walk aborted
+        // before doing any work, exactly like EmbedSpawner's equivalent check.
+        assertThat(counting.invocations.get()).isEqualTo(0);
+    }
+
+    @Test
+    public void testInterruptAbortsBetweenEntriesNotOnlyTheFirst() throws Exception {
+        // Simulates a multi-embed walk: the first entry parses normally, then a cancellation
+        // fires mid-walk (Extractor's parse-timeout interrupting the thread), and the SECOND
+        // entry must abort immediately instead of being parsed -- the "aborts between entries"
+        // behavior the fix is meant to guarantee.
+        final CountingParser counting = new CountingParser();
+        final EmbedParser parser = new EmbedParser(root(), new ParseContext(), counting);
+
+        parser.delegateParsing(payload(), new BodyContentHandler(), nonInline("entry-1.bin"));
+        assertThat(counting.invocations.get()).isEqualTo(1);
+
+        Thread.currentThread().interrupt();
+        try {
+            parser.delegateParsing(payload(), new BodyContentHandler(), nonInline("entry-2.bin"));
+            fail("expected InterruptedIOException");
+        } catch (final InterruptedIOException expected) {
+            // expected
+        } finally {
+            Thread.interrupted(); // clear so we don't poison the test-runner thread
+        }
+
+        // Entry 2 was never handed to the delegate parser.
+        assertThat(counting.invocations.get()).isEqualTo(1);
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedArtifactWriterTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedArtifactWriterTest.java
@@ -12,6 +12,16 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -82,5 +92,65 @@ public class EmbeddedArtifactWriterTest {
         File written = EmbeddedArtifactWriter.write(root, ID, metadata, second);
 
         assertThat(Files.readAllBytes(written.toPath())).isEqualTo("twotwo".getBytes());
+    }
+
+    // F1/N2: two ARTIFACT workers can re-extract the same root concurrently under
+    // parallelism > 1 and both call write() for the SAME id at the same time. Before the fix,
+    // write() copies straight to the final "raw" path (FileOutputStream/Files.copy with
+    // REPLACE_EXISTING truncating in place), so a concurrent reader can observe a raw file whose
+    // length is neither 0 nor the full expected size -- a truncation window that, combined with a
+    // crash mid-write, is what leaves a permanently truncated cache entry (N2). After the fix
+    // (write-to-temp-then-atomic-move), the final path only ever shows up complete or not at all.
+    @Test(timeout = 60000)
+    public void test_concurrent_writes_to_same_id_never_expose_a_partial_raw_file() throws Exception {
+        Path root = tmp.getRoot().toPath();
+        byte[] content = new byte[5 * 1024 * 1024];
+        new Random(42).nextBytes(content);
+        Path source = tmp.newFile("payload.bin").toPath();
+        Files.write(source, content);
+        Metadata metadata = metadataWithName("payload.bin");
+
+        File rawFile = EmbeddedArtifactWriter.rawPath(root, ID).toFile();
+
+        int writerThreads = 8;
+        int iterations = 15;
+        ExecutorService pool = Executors.newFixedThreadPool(writerThreads + 1);
+        List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+        AtomicBoolean stop = new AtomicBoolean(false);
+        AtomicInteger partialSightings = new AtomicInteger(0);
+
+        Future<?> readerFuture = pool.submit(() -> {
+            while (!stop.get()) {
+                long len = rawFile.length(); // 0 when absent
+                if (len != 0 && len != content.length) {
+                    partialSightings.incrementAndGet();
+                }
+            }
+        });
+
+        List<Future<?>> writers = new ArrayList<>();
+        for (int t = 0; t < writerThreads; t++) {
+            writers.add(pool.submit(() -> {
+                try {
+                    for (int i = 0; i < iterations; i++) {
+                        EmbeddedArtifactWriter.write(root, ID, metadata, source);
+                    }
+                } catch (Throwable e) {
+                    errors.add(e);
+                }
+            }));
+        }
+        for (Future<?> f : writers) {
+            f.get();
+        }
+        stop.set(true);
+        readerFuture.get();
+        pool.shutdown();
+        pool.awaitTermination(5, TimeUnit.SECONDS);
+
+        assertThat(errors).isEmpty();
+        assertThat(partialSightings.get()).isEqualTo(0);
+        assertThat(Files.readAllBytes(rawFile.toPath())).isEqualTo(content);
+        assertThat(new File(rawFile + ".json")).isFile();
     }
 }

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedArtifactWriterTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedArtifactWriterTest.java
@@ -1,6 +1,5 @@
 package org.icij.extract.extractor;
 
-import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.icij.spewer.MetadataTransformer;
@@ -61,22 +60,6 @@ public class EmbeddedArtifactWriterTest {
         assertThat(sidecar).isFile();
         assertThat(Files.readAllBytes(sidecar.toPath()))
                 .isEqualTo(new MetadataTransformer(metadata).transform().getBytes(Charset.defaultCharset()));
-    }
-
-    @Test
-    public void test_write_from_tika_input_stream_creates_raw_and_sidecar_and_resets() throws Exception {
-        Path root = tmp.getRoot().toPath();
-        Path source = tmp.newFile("stream.bin").toPath();
-        Files.write(source, "streamed".getBytes());
-        Metadata metadata = metadataWithName("stream.bin");
-
-        try (TikaInputStream tis = TikaInputStream.get(source)) {
-            File written = EmbeddedArtifactWriter.write(root, ID, metadata, tis);
-            assertThat(Files.readAllBytes(written.toPath())).isEqualTo("streamed".getBytes());
-            assertThat(new File(written + ".json")).isFile();
-            // reset() was called: the stream is readable again from the start.
-            assertThat(tis.read()).isEqualTo((int) 's');
-        }
     }
 
     @Test

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorPstIdParityTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorPstIdParityTest.java
@@ -1,0 +1,92 @@
+package org.icij.extract.extractor;
+
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.EmbeddedTikaDocument;
+import org.icij.extract.document.TikaDocument;
+import org.icij.spewer.Spewer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * OST-2 regression guard. The ARTIFACT/download retrieval walk
+ * ({@link EmbeddedDocumentExtractor#extractAll}) must write each embed's raw bytes under the SAME
+ * content-addressed id the INDEX walk ({@link EmbedSpawner}, via {@link Extractor}) produced for
+ * that embed. Both ids are composed by {@link DigestIdentifier#generateForEmbed} from
+ * {@code content-hash || parentId || EMBEDDED_RELATIONSHIP_ID || resourceName}. For a PST/OST the
+ * EMBEDDED_RELATIONSHIP_ID (Message-ID) and resourceName/Content-Type are populated DURING the
+ * message sub-parse, so if retrieval freezes the id BEFORE that sub-parse (the bug) every message
+ * -- and by parent-id cascade every attachment -- gets a different id and its raw bytes land under
+ * an id datashare never polls (RawArtifact then finds no {@code raw}).
+ *
+ * <p>Uses the same multi-folder {@code testPST.pst} fixture the fan-out determinism test relies on,
+ * driven with the production salted digester + DigestIdentifier so ids match exactly. RED before the
+ * fix (id sets diverge: messages + attachments mismatch), GREEN after (id sets equal).
+ */
+public class EmbeddedDocumentExtractorPstIdParityTest {
+
+    private static final String PST = "/documents/pst/testPST.pst";
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private DocumentFactory factory() {
+        return new DocumentFactory().withIdentifier(new DigestIdentifier("SHA-256", StandardCharsets.UTF_8));
+    }
+
+    private void collect(final TikaDocument doc, final Set<String> ids) {
+        for (final EmbeddedTikaDocument embed : doc.getEmbeds()) {
+            ids.add(embed.getId());
+            collect(embed, ids);
+        }
+    }
+
+    @Test(timeout = 300_000)
+    public void retrieval_extractAll_ids_match_index_embed_ids() throws Exception {
+        final Path pst = Paths.get(getClass().getResource(PST).toURI());
+        final DocumentFactory factory = factory();
+
+        // INDEX walk (EmbedSpawner): parse the PST serially, read the whole tree, then collect the
+        // id of every embed at every level -- these are the ids datashare indexes and later polls.
+        final TreeSet<String> indexIds = new TreeSet<>();
+        try (Extractor extractor = new Extractor(factory)) {
+            extractor.setDigester(new UpdatableDigester("prj", "SHA-256"));
+            final TikaDocument indexRoot = extractor.extract(pst);
+            try (Reader r = indexRoot.getReader()) { Spewer.toString(r); }
+            collect(indexRoot, indexIds);
+        }
+        assertThat(indexIds).as("index produced embed ids").isNotEmpty();
+        assertThat(indexIds.size()).as("fixture is genuinely multi-embed").isGreaterThan(1);
+
+        // RETRIEVAL walk (EmbeddedDocumentExtractor.extractAll): re-extract every embed's bytes to
+        // the artifact dir. A fresh root off the same file + factory has the same root id, so the
+        // whole id chain is comparable. The written ids are the <id> dir names under artifactPath.
+        final Path artifactPath = tmp.newFolder("artifacts").toPath();
+        final TikaDocument retrievalRoot = factory.create(pst);
+        new EmbeddedDocumentExtractor(new UpdatableDigester("prj", "SHA-256"), artifactPath).extractAll(retrievalRoot);
+
+        final TreeSet<String> retrievalIds = new TreeSet<>();
+        try (Stream<Path> walk = Files.walk(artifactPath)) {
+            walk.filter(p -> p.getFileName().toString().equals("raw"))
+                .forEach(raw -> retrievalIds.add(raw.getParent().getFileName().toString()));
+        }
+
+        // The two roots must agree on the root id, or nothing below could match.
+        assertThat(retrievalRoot.getId()).as("root id parity").isNotNull();
+
+        // The crux: retrieval must have written raw bytes under exactly the indexed embed ids.
+        assertThat(retrievalIds).as("retrieval raw ids == index embed ids").isEqualTo(indexIds);
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorPstParserTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorPstParserTest.java
@@ -1,0 +1,58 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.parser.CompositeParser;
+import org.apache.tika.parser.DigestingParser;
+import org.apache.tika.parser.Parser;
+import org.apache.tika.parser.ParserDecorator;
+import org.apache.tika.parser.microsoft.pst.OutlookPSTParser;
+import org.icij.extract.parser.ResilientOutlookPSTParser;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Verifies that {@link EmbeddedDocumentExtractor} -- the parser used by the ARTIFACT/download
+ * re-extraction path -- wires in the resilient Outlook PST parser instead of Tika's stock one,
+ * the same replacement {@link Extractor} applies at INDEX time. Without it, retrieval of any
+ * document embedded in a PST/OST fails with Tika's stock parser (e.g. "OST 2013 support not
+ * added yet"), even though the very same file indexed fine.
+ */
+public class EmbeddedDocumentExtractorPstParserTest {
+
+    @Test
+    public void test_parser_replaces_stock_outlook_pst_parser_without_ocr() {
+        //GIVEN an extractor built the same way ARTIFACT/download re-extraction builds it (no OCR)
+        EmbeddedDocumentExtractor extractor = new EmbeddedDocumentExtractor(
+                new UpdatableDigester("prj", "SHA-256"), "SHA-256", Paths.get("/tmp"), false);
+
+        //WHEN/THEN
+        assertResilientOutlookParserIsWired(extractor);
+    }
+
+    @Test
+    public void test_parser_replaces_stock_outlook_pst_parser_with_ocr() {
+        //GIVEN an extractor built the same way ARTIFACT/download re-extraction builds it (with OCR)
+        EmbeddedDocumentExtractor extractor = new EmbeddedDocumentExtractor(
+                new UpdatableDigester("prj", "SHA-256"), "SHA-256", Paths.get("/tmp"), true);
+
+        //WHEN/THEN
+        assertResilientOutlookParserIsWired(extractor);
+    }
+
+    private void assertResilientOutlookParserIsWired(EmbeddedDocumentExtractor extractor) {
+        Parser wrapped = extractor.getParser();
+        assertThat(wrapped).isInstanceOf(DigestingParser.class);
+        Parser base = ((ParserDecorator) wrapped).getWrappedParser();
+        assertThat(base).isInstanceOf(CompositeParser.class);
+
+        boolean hasResilientParser = Extractor.getAllSubParsers((CompositeParser) base)
+                .anyMatch(ResilientOutlookPSTParser.class::isInstance);
+        boolean hasStockParser = Extractor.getAllSubParsers((CompositeParser) base)
+                .anyMatch(p -> p.getClass().equals(OutlookPSTParser.class));
+
+        assertThat(hasResilientParser).isTrue();
+        assertThat(hasStockParser).isFalse();
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorStackBalanceTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorStackBalanceTest.java
@@ -1,0 +1,120 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.parser.DigestingParser;
+import org.apache.tika.parser.ParseContext;
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.TikaDocument;
+import org.icij.extract.document.TikaDocumentSource;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.Fail.fail;
+
+/**
+ * F4a: {@code DigestEmbeddedDocumentExtractor.delegateParsing} pushes the current embed onto
+ * {@code documentStack} LATE (after digesting/documentCallback), but the {@code finally} block
+ * always pops. If digest() throws before the push -- a per-message parse/digest failure, the
+ * kind a resilient container isolates per-entry (see
+ * {@link org.icij.extract.parser.ResilientOutlookPSTParser#emitMessage}, which catches and
+ * continues to the next sibling) -- the {@code finally} still pops the parent this call never
+ * pushed, underflowing the stack for every embed walked afterwards.
+ */
+public class EmbeddedDocumentExtractorStackBalanceTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private static final byte[] FAILING_CONTENT = "first message body".getBytes();
+    private static final byte[] OK_CONTENT = "second message body".getBytes();
+
+    private DocumentFactory documentFactory;
+    private Path rootFile;
+
+    @Before
+    public void setUp() throws Exception {
+        documentFactory = new DocumentFactory().withIdentifier(new DigestIdentifier("SHA-256", Charset.defaultCharset()));
+        rootFile = tmp.newFile("root.bin").toPath();
+        Files.write(rootFile, "root content".getBytes());
+    }
+
+    private static Metadata messageMetadata(String name) {
+        Metadata metadata = new Metadata();
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+        return metadata;
+    }
+
+    // A root TikaDocument only gets a resolvable getId() once its metadata has been digested;
+    // normally that happens as a side effect of the outer DigestingParser parsing the root
+    // document in EmbeddedDocumentExtractor.extract()/extractAll(). Since this test drives
+    // delegateParsing directly (bypassing that outer parse), digest the root explicitly so
+    // embed.getParent().getId() resolves instead of NPE-ing on a missing hash.
+    private TikaDocument freshDigestedRoot(DigestingParser.Digester digester) throws Exception {
+        TikaDocument root = documentFactory.create(rootFile);
+        try (TikaInputStream tis = TikaInputStream.get(rootFile)) {
+            digester.digest(tis, root.getMetadata(), new ParseContext());
+        }
+        return root;
+    }
+
+    @Test
+    public void a_failed_message_before_the_stack_push_does_not_cascade_to_the_next_sibling() throws Exception {
+        //GIVEN the id the second (valid) message would get in a normal walk, computed with a
+        // real digester against a throwaway root instance pointing at the same file.
+        UpdatableDigester realDigester = new UpdatableDigester("prj", "SHA-256");
+        TikaDocument controlRoot = freshDigestedRoot(realDigester);
+        EmbeddedDocumentExtractor.DigestEmbeddedDocumentMemoryExtractor control =
+                new EmbeddedDocumentExtractor.DigestEmbeddedDocumentMemoryExtractor(
+                        controlRoot, "unused-sentinel", new ParseContext(), realDigester, "SHA-256");
+        control.delegateParsing(new ByteArrayInputStream(FAILING_CONTENT), new DefaultHandler(), messageMetadata("message-1.eml"));
+        control.delegateParsing(new ByteArrayInputStream(OK_CONTENT), new DefaultHandler(), messageMetadata("message-2.eml"));
+        String secondMessageId = controlRoot.getEmbeds().get(1).getId();
+
+        //GIVEN a digester that throws on the FIRST digest() call only (simulating one bad
+        // message a resilient container isolates -- catches, logs, moves to the next sibling)
+        // and delegates to the real digester afterwards.
+        AtomicInteger calls = new AtomicInteger();
+        DigestingParser.Digester flakyDigester = (is, metadata, context) -> {
+            if (calls.getAndIncrement() == 0) {
+                throw new IOException("simulated per-message digest failure");
+            }
+            realDigester.digest(is, metadata, context);
+        };
+        TikaDocument testRoot = freshDigestedRoot(realDigester);
+        EmbeddedDocumentExtractor.DigestEmbeddedDocumentMemoryExtractor extractor =
+                new EmbeddedDocumentExtractor.DigestEmbeddedDocumentMemoryExtractor(
+                        testRoot, secondMessageId, new ParseContext(), flakyDigester, "SHA-256");
+
+        //WHEN the first message's digest fails and the caller isolates it, the way a resilient
+        // container does
+        try {
+            extractor.delegateParsing(new ByteArrayInputStream(FAILING_CONTENT), new DefaultHandler(), messageMetadata("message-1.eml"));
+            fail("expected the simulated digest failure to propagate to the caller");
+        } catch (IOException expected) {
+            // isolated by the caller; the walk must go on to the next sibling
+        }
+
+        //THEN the stack must not be corrupted: the second, valid sibling is still walked and
+        // found, instead of the earlier failure underflowing the stack and breaking every
+        // subsequent embed.
+        extractor.delegateParsing(new ByteArrayInputStream(OK_CONTENT), new DefaultHandler(), messageMetadata("message-2.eml"));
+
+        TikaDocumentSource found = extractor.getDocument();
+        assertThat(found).isNotNull();
+        assertThat(new String(found.getContent())).isEqualTo(new String(OK_CONTENT));
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorUnreadableEmbedTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorUnreadableEmbedTest.java
@@ -3,7 +3,9 @@ package org.icij.extract.extractor;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.Parser;
 import org.icij.extract.document.DigestIdentifier;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.document.EmbeddedTikaDocument;
@@ -12,6 +14,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.ByteArrayInputStream;
@@ -21,6 +24,8 @@ import java.io.InterruptedIOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.Fail.fail;
@@ -124,6 +129,55 @@ public class EmbeddedDocumentExtractorUnreadableEmbedTest {
         assertThat(Files.size(good1Raw)).isGreaterThan(0L);
         assertThat(Files.size(good2Raw)).isGreaterThan(0L);
         //AND (3) the walk continued past the failure without cascading (the third call did not throw)
+    }
+
+    // A parser that always throws a non-Tika RuntimeException, reproducing a sub-parse failure that
+    // hits AFTER the entry has been successfully spooled + digested (unlike the read failure above,
+    // which throws while spooling). EmbedParser.delegateParsing only catches Tika exceptions, so this
+    // propagates into DigestEmbeddedDocumentExtractor's per-embed catch.
+    private static Parser subParseFailingParser() {
+        return new Parser() {
+            @Override
+            public Set<MediaType> getSupportedTypes(ParseContext context) {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context) {
+                throw new IllegalStateException("sub-parse boom");
+            }
+        };
+    }
+
+    @Test
+    public void spooled_embed_with_failing_subparse_writes_real_bytes_under_content_full_id() throws Exception {
+        //GIVEN a write-all extractor whose delegate parser throws only during the sub-parse, so the
+        //embed's bytes are spooled and digested OK before the failure (id is CONTENT-FULL)
+        Path artifactDir = tmp.newFolder("artifacts").toPath();
+        UpdatableDigester digester = new UpdatableDigester("prj", "SHA-256");
+        TikaDocument root = freshDigestedRoot(digester);
+        ParseContext context = new ParseContext();
+        context.set(Parser.class, subParseFailingParser());
+        EmbeddedDocumentExtractor.DigestAllEmbeddedDocumentExtractor extractor =
+                new EmbeddedDocumentExtractor.DigestAllEmbeddedDocumentExtractor(
+                        root, context, digester, "SHA-256", artifactDir);
+
+        //WHEN an embed with real, readable bytes is walked and its sub-parse throws
+        byte[] realBytes = "real-embedded-content".getBytes();
+        try {
+            extractor.delegateParsing(new ByteArrayInputStream(realBytes), new DefaultHandler(), named("has-bytes.bin"));
+            fail("expected the sub-parse failure to propagate to the caller's per-attachment isolation");
+        } catch (RuntimeException isolated) {
+            assertThat(isolated).isInstanceOf(IllegalStateException.class);
+        }
+
+        //THEN the embed's REAL bytes are written under its content-full id (NOT an empty raw)
+        assertThat(root.getEmbeds()).hasSize(1);
+        EmbeddedTikaDocument embed = root.getEmbeds().get(0);
+        assertThat(embed.getHash()).isNotNull(); // digest ran -> content-full id (contrast the read-fail case)
+        Path raw = EmbeddedDocumentExtractor.getEmbeddedPath(artifactDir, embed.getId());
+        assertThat(raw.toFile()).isFile();
+        assertThat(Files.readAllBytes(raw)).isEqualTo(realBytes);
     }
 
     @Test

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorUnreadableEmbedTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentExtractorUnreadableEmbedTest.java
@@ -1,0 +1,155 @@
+package org.icij.extract.extractor;
+
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.parser.ParseContext;
+import org.icij.extract.document.DigestIdentifier;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.EmbeddedTikaDocument;
+import org.icij.extract.document.TikaDocument;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.Fail.fail;
+
+/**
+ * OST-4b: an embed whose bytes cannot be read (an OST-2013 multi-block TRUNCATED by-value
+ * attachment throws {@link IndexOutOfBoundsException} at {@code com.pff.PSTNodeInputStream.read}
+ * during the retrieval walk's per-embed spool) must NOT leave that embed's id with no raw.
+ * The index (EmbedSpawner) keeps such an embed and composes a CONTENT-LESS id for it
+ * ({@link DigestIdentifier} null-hash path), then polls it; if the retrieval walk lets the read
+ * failure propagate past the write, {@code RawArtifact} reports "produced no bytes" (F4b).
+ *
+ * The retrieval walk therefore mirrors EmbedSpawner's per-embed resilience: on a read/parse
+ * failure it writes a zero-byte raw under the SAME id (embed.getId() with no content hash ==
+ * the indexed id) before letting the exception propagate, so Tika's per-attachment isolation
+ * continues the walk to the next sibling exactly as before, only now every visited embed's id
+ * resolves. Cancellation (an interrupt) is never swallowed.
+ */
+public class EmbeddedDocumentExtractorUnreadableEmbedTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private DocumentFactory documentFactory;
+    private Path rootFile;
+
+    @Before
+    public void setUp() throws Exception {
+        documentFactory = new DocumentFactory().withIdentifier(new DigestIdentifier("SHA-256", Charset.defaultCharset()));
+        rootFile = tmp.newFile("root.bin").toPath();
+        Files.write(rootFile, "root content".getBytes());
+    }
+
+    private static Metadata named(String name) {
+        Metadata metadata = new Metadata();
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+        return metadata;
+    }
+
+    // A root only has a resolvable getId() once its metadata is digested; the direct-drive tests
+    // below bypass the outer parse that normally does this, so digest the root explicitly (mirrors
+    // EmbeddedDocumentExtractorStackBalanceTest.freshDigestedRoot).
+    private TikaDocument freshDigestedRoot(UpdatableDigester digester) throws Exception {
+        TikaDocument root = documentFactory.create(rootFile);
+        try (TikaInputStream tis = TikaInputStream.get(rootFile)) {
+            digester.digest(tis, root.getMetadata(), new ParseContext());
+        }
+        return root;
+    }
+
+    // Reading this stream throws IndexOutOfBoundsException on first read, reproducing the
+    // com.pff.PSTNodeInputStream.read defect on a multi-block truncated by-value attachment.
+    private static InputStream unreadableStream() {
+        return new InputStream() {
+            @Override
+            public int read() {
+                throw new IndexOutOfBoundsException("Index: 5, Size: 5");
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) {
+                throw new IndexOutOfBoundsException("Index: 5, Size: 5");
+            }
+        };
+    }
+
+    @Test
+    public void unreadable_embed_writes_content_less_raw_and_siblings_survive() throws Exception {
+        //GIVEN the extractAll write-all extractor over an artifact dir
+        Path artifactDir = tmp.newFolder("artifacts").toPath();
+        UpdatableDigester digester = new UpdatableDigester("prj", "SHA-256");
+        TikaDocument root = freshDigestedRoot(digester);
+        EmbeddedDocumentExtractor.DigestAllEmbeddedDocumentExtractor extractor =
+                new EmbeddedDocumentExtractor.DigestAllEmbeddedDocumentExtractor(
+                        root, new ParseContext(), digester, "SHA-256", artifactDir);
+
+        //WHEN a healthy sibling, then an unreadable embed, then another healthy sibling are walked
+        extractor.delegateParsing(new ByteArrayInputStream("good-1".getBytes()), new DefaultHandler(), named("good1.txt"));
+        try {
+            extractor.delegateParsing(unreadableStream(), new DefaultHandler(), named("bad.jpg"));
+            fail("expected the read failure to propagate to the caller's per-attachment isolation");
+        } catch (RuntimeException isolated) {
+            // Isolated by the caller, exactly like Tika does around each attachment at index/retrieval.
+            assertThat(isolated).isInstanceOf(IndexOutOfBoundsException.class);
+        }
+        extractor.delegateParsing(new ByteArrayInputStream("good-2".getBytes()), new DefaultHandler(), named("good2.txt"));
+
+        //THEN (1) the failing embed still gets a zero-byte raw under the content-less id the index composes
+        assertThat(root.getEmbeds()).hasSize(3);
+        EmbeddedTikaDocument bad = root.getEmbeds().get(1);
+        assertThat(bad.getHash()).isNull(); // no file digest -> content-less id (DigestIdentifier null-hash path)
+        Path badRaw = EmbeddedDocumentExtractor.getEmbeddedPath(artifactDir, bad.getId());
+        assertThat(badRaw.toFile()).isFile();
+        assertThat(Files.size(badRaw)).isEqualTo(0L);
+
+        //AND (2) both sibling embeds are still written with their real bytes
+        Path good1Raw = EmbeddedDocumentExtractor.getEmbeddedPath(artifactDir, root.getEmbeds().get(0).getId());
+        Path good2Raw = EmbeddedDocumentExtractor.getEmbeddedPath(artifactDir, root.getEmbeds().get(2).getId());
+        assertThat(good1Raw.toFile()).isFile();
+        assertThat(good2Raw.toFile()).isFile();
+        assertThat(Files.size(good1Raw)).isGreaterThan(0L);
+        assertThat(Files.size(good2Raw)).isGreaterThan(0L);
+        //AND (3) the walk continued past the failure without cascading (the third call did not throw)
+    }
+
+    @Test
+    public void interrupt_propagates_and_writes_no_content_less_raw() throws Exception {
+        //GIVEN the same write-all extractor and an interrupted walk thread (cooperative cancellation)
+        Path artifactDir = tmp.newFolder("artifacts").toPath();
+        UpdatableDigester digester = new UpdatableDigester("prj", "SHA-256");
+        TikaDocument root = freshDigestedRoot(digester);
+        EmbeddedDocumentExtractor.DigestAllEmbeddedDocumentExtractor extractor =
+                new EmbeddedDocumentExtractor.DigestAllEmbeddedDocumentExtractor(
+                        root, new ParseContext(), digester, "SHA-256", artifactDir);
+
+        //WHEN the thread is interrupted before an embed is parsed
+        Thread.currentThread().interrupt();
+        try {
+            extractor.delegateParsing(new ByteArrayInputStream("x".getBytes()), new DefaultHandler(), named("cancelled.txt"));
+            fail("expected InterruptedIOException to propagate (cancellation must not be swallowed)");
+        } catch (InterruptedIOException expected) {
+            // (4) cancellation aborts and is NOT turned into a content-less write
+        } finally {
+            Thread.interrupted(); // clear the flag so it never leaks to another test
+        }
+
+        //THEN no raw was written for the cancelled embed
+        assertThat(root.getEmbeds()).hasSize(1);
+        Path cancelledRaw = EmbeddedDocumentExtractor.getEmbeddedPath(artifactDir, root.getEmbeds().get(0).getId());
+        assertThat(cancelledRaw.toFile().exists()).isFalse();
+    }
+}

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
@@ -13,12 +13,21 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
 import java.io.Reader;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -119,6 +128,68 @@ public class EmbeddedDocumentMemoryExtractorTest {
         //THEN
         assertThat(tmp.getRoot().toPath().resolve("prj").toFile()).isDirectory();
         assertThat(tmp.getRoot().toPath().resolve("prj").toFile().listFiles()).hasSize(11);
+    }
+
+    @Test
+    public void extractAll_does_not_leak_root_file_descriptors() throws Exception {
+        // GIVEN a subprocess pinned to an allocation-only GC (Epsilon). A regular collector
+        // reclaims an unreferenced, unclosed FileInputStream (and its native fd) via its
+        // Cleaner action on pretty much every young GC, which happens so often during this
+        // parse workload that a real per-call fd leak is invisible if measured in-process.
+        // Epsilon never collects, so any leaked fd has nowhere to hide.
+        String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        ProcessBuilder builder = new ProcessBuilder(javaBin,
+                "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+                "-XX:+UnlockExperimentalVMOptions", "-XX:+UseEpsilonGC", "-Xmx1536m",
+                "-cp", System.getProperty("java.class.path"),
+                EmbeddedDocumentMemoryExtractorTest.class.getName(),
+                tmp.getRoot().toPath().resolve("prj").toString(), "60");
+        builder.redirectErrorStream(true);
+        Process process = builder.start();
+        String output;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            output = reader.lines().collect(Collectors.joining("\n"));
+        }
+        int exitCode = process.waitFor();
+
+        //THEN the root file stream must be closed after each parse, so the descriptor
+        // count in the subprocess stays flat instead of growing by ~1 per iteration
+        assertThat(exitCode).isEqualTo(0);
+        Matcher matcher = Pattern.compile("FD_DIFF=(-?\\d+)").matcher(output);
+        assertThat(matcher.find()).isTrue();
+        assertThat(Long.parseLong(matcher.group(1))).isLessThan(20);
+    }
+
+    /**
+     * Entry point for the subprocess spawned by {@link #extractAll_does_not_leak_root_file_descriptors()}.
+     * Runs outside JUnit/Maven's own fork so it can pin the GC to Epsilon.
+     */
+    public static void main(String[] args) throws Exception {
+        Path artifactPath = Paths.get(args[0]);
+        int iterations = Integer.parseInt(args[1]);
+        DocumentFactory documentFactory = new DocumentFactory()
+                .withIdentifier(new DigestIdentifier("SHA-256", Charset.defaultCharset()));
+        TikaDocument document = documentFactory.create(
+                EmbeddedDocumentMemoryExtractorTest.class.getResource("/documents/recursive_embedded.docx"));
+        EmbeddedDocumentExtractor extractor = new EmbeddedDocumentExtractor(
+                new UpdatableDigester("prj", "SHA-256"), artifactPath);
+
+        long before = openFileDescriptorCount();
+        for (int i = 0; i < iterations; i++) {
+            extractor.extractAll(document);
+        }
+        long after = openFileDescriptorCount();
+        System.out.println("FD_DIFF=" + (after - before));
+    }
+
+    private static long openFileDescriptorCount() throws Exception {
+        OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+        if (osBean instanceof com.sun.management.UnixOperatingSystemMXBean) {
+            return ((com.sun.management.UnixOperatingSystemMXBean) osBean).getOpenFileDescriptorCount();
+        }
+        try (Stream<Path> fds = Files.list(Paths.get("/proc/self/fd"))) {
+            return fds.count();
+        }
     }
 
     @Test(expected = IllegalStateException.class)

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
@@ -101,6 +101,28 @@ public class EmbeddedDocumentMemoryExtractorTest {
     }
 
     @Test
+    public void test_extract_falls_back_to_live_parse_when_cached_sidecar_is_missing() throws Exception {
+        //GIVEN a cache entry whose raw payload exists but whose sidecar was lost (crash/partial
+        // write, or the entry simply predates a format change) -- N2: this must degrade to a cache
+        // miss (live re-parse) rather than a permanent failure, since the source is re-derivable.
+        EmbeddedDocumentExtractor extractor = new EmbeddedDocumentExtractor(
+                new UpdatableDigester("prj", "SHA-256"), tmp.getRoot().toPath());
+        String digest = "1eeb334ca60c61baca50b9df851b60c52b856c727932d0d1cae4e56a34190e7e";
+        extractor.extract(tikaDocument, digest);
+        File cachedFile = EmbeddedDocumentExtractor.getEmbeddedPath(tmp.getRoot().toPath(), digest).toFile();
+        File sidecar = new File(cachedFile + ".json");
+        assertThat(sidecar.isFile()).isTrue();
+        assertThat(sidecar.delete()).isTrue();
+
+        //WHEN
+        TikaDocumentSource emfImage = extractor.extract(tikaDocument, digest);
+
+        //THEN it must not throw and must still return the correct bytes via a live re-parse
+        assertThat(emfImage).isNotNull();
+        assertThat(emfImage.getContent()).hasSize(4992);
+    }
+
+    @Test
     public void test_embedded_file_extraction_level_1_should_use_cache_if_it_exists() throws Exception {
         //GIVEN
         EmbeddedDocumentExtractor extractor = new EmbeddedDocumentExtractor(

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
@@ -8,6 +8,7 @@ import org.icij.extract.document.TikaDocumentSource;
 import org.icij.extract.extractor.EmbeddedDocumentExtractor.ContentNotFoundException;
 import org.icij.spewer.Spewer;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -160,6 +161,21 @@ public class EmbeddedDocumentMemoryExtractorTest {
         // parse workload that a real per-call fd leak is invisible if measured in-process.
         // Epsilon never collects, so any leaked fd has nowhere to hide.
         String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+
+        // Some hardened CI JVMs disable experimental VM options outright, which would make
+        // the subprocess below exit non-zero before it ever runs the parse loop -- not a real
+        // fd leak, just an environment that can't run this probe. Skip (don't fail) in that
+        // case with a cheap "-version" pre-check; the real leak assertion below stays intact
+        // and un-weakened wherever Epsilon-GC is actually available.
+        Process precheck = new ProcessBuilder(javaBin,
+                "-XX:+UnlockExperimentalVMOptions", "-XX:+UseEpsilonGC", "-version")
+                .redirectErrorStream(true).start();
+        precheck.getInputStream().readAllBytes(); // drain so the process can exit
+        boolean epsilonGcAvailable = precheck.waitFor() == 0;
+        Assume.assumeTrue(
+                "JVM rejects -XX:+UnlockExperimentalVMOptions/-XX:+UseEpsilonGC on this host; skipping fd-leak probe",
+                epsilonGcAvailable);
+
         ProcessBuilder builder = new ProcessBuilder(javaBin,
                 "--add-opens", "java.base/java.lang=ALL-UNNAMED",
                 "-XX:+UnlockExperimentalVMOptions", "-XX:+UseEpsilonGC", "-Xmx1536m",

--- a/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/extractor/EmbeddedDocumentMemoryExtractorTest.java
@@ -382,15 +382,19 @@ public class EmbeddedDocumentMemoryExtractorTest {
                 new UpdatableDigester("local-datashare", "SHA-384"), "SHA-384", tmp.getRoot().toPath(), false);
 
         //WHEN/THEN
+        // These ids are composed AFTER the embed sub-parse (OST-2 fix): DigestIdentifier folds
+        // EMBEDDED_RELATIONSHIP_ID / resourceName into the id, and those are populated by the .msg
+        // sub-parse. The retrieval walk now freezes the id after that sub-parse, exactly as the
+        // index (EmbedSpawner) walk does, so these values match the indexed ids.
         TikaDocumentSource test2 = contentExtractor.extract(tikaDocument256,
-                "48ff8c7811277eaa17d0455cb83f9ffa53db86cc3f90f35a4d48031ecb103c039b2864857d3ed5886ecd45581eebde73");
+                "e215f4a3856edd816253d30fe65df3af13ee8fcdffb9d78f71f74c91d9d68040711c2e9cfc738018b5e82baec2f824a1");
         assertThat(test2).isNotNull();
         TikaDocumentSource test = contentExtractor.extract(tikaDocument256,
-                "e571ca1d275d9fc6f9ad2856786ff7efbfc7475b6d20d3cc5c0793b3e163978edcde26d09722996f45130561eecc0350");
+                "7f2ef2e56d30ea00d05f9c5f9415f7d3715d6fd4990d8f1c1bcc085c29b94a5c5aac25e92381ee3ca795810049d2f769");
         assertThat(test).isNotNull();
         assertThat(test2.metadata().get("resourceName")).contains("Test2.msg");
         TikaDocumentSource pdf = contentExtractor.extract(tikaDocument256,
-                "f27a5ea51ffc8a9a023e5bf46930b6e9f112ff508008fa13ac3fc81cac3a7dfa2176cd25a94d0f6a9de82d44c2ccbc3a");
+                "6cfea149d2931cdd03317d933dac2a05065e584d582daca127aca715b3b202b6f5a4059bed425b3c82b83000078880d2");
         assertThat(pdf.metadata().get("resourceName")).contains("POD Layout ICIJ 2020.pdf");
     }
 


### PR DESCRIPTION
Embedded-document extraction reliability fixes for the ARTIFACT/download path. On a real 66 MB OST, embed retrieval went from 16/289 to 289/289 (0 holes). No version bump here — cut the release on master after merge (datashare then points at it).

- fix: close the leaked root file stream in `EmbeddedDocumentExtractor` (FD exhaustion)
- fix: use `ResilientOutlookPSTParser` on the retrieval path to match index time (OST/PST parsing)
- fix: write `raw`/`raw.json` atomically with live-parse fallback on a bad cache
- fix: cooperative interrupt check in `EmbedParser` so a cancelled walk aborts
- fix: keep the embed document stack balanced so one failed message doesn't cascade
- fix: freeze embed ids after the sub-parse so retrieval ids match index ids
- fix: on a per-embed read failure, write an index-matching artifact instead of dropping it
- test: skip the FD-leak test when the JVM rejects Epsilon-GC instead of failing CI
- refactor: remove dead `TikaInputStream` write overloads
