### PR TITLE
fix(ocr): strip the image/ocr- routing prefix even when the OCR parse fails

### DIFF
--- a/extract-lib/src/main/java/org/icij/extract/ocr/OCRParserAdapter.java
+++ b/extract-lib/src/main/java/org/icij/extract/ocr/OCRParserAdapter.java
@@ -41,13 +41,19 @@ public class OCRParserAdapter<P extends Parser> implements Parser {
             throw new NullPointerException("Parser is null");
         }
         metadata.set(OCRParser.OCR_PARSER, delegatedParser.getClass().getName());
-        delegatedParser.parse(stream, handler, metadata, parseContext);
-        // The delegated OCR parser has already resolved its input format from
-        // CONTENT_TYPE_PARSER_OVERRIDE, so it is now safe to rewrite the routing type back to the real
-        // media type. Stripping the override is the effective fix (Tika promotes it onto Content-Type
-        // after this parse returns); Content-Type is normalised too as a defensive measure.
-        restoreMediaType(metadata, CONTENT_TYPE_PARSER_OVERRIDE);
-        restoreMediaType(metadata, Metadata.CONTENT_TYPE);
+        try {
+            delegatedParser.parse(stream, handler, metadata, parseContext);
+        } finally {
+            // The delegated OCR parser has already resolved its input format from
+            // CONTENT_TYPE_PARSER_OVERRIDE, so it is now safe to rewrite the routing type back to the real
+            // media type. Stripping the override is the effective fix (Tika promotes it onto Content-Type
+            // after this parse returns); Content-Type is normalised too as a defensive measure.
+            // This runs in a finally because a failed OCR parse (Tess4JOCRParser rethrows IOException /
+            // TikaException, e.g. on the OCR timeout) still leaves the embed indexed by EmbedSpawner, so
+            // the routing type would otherwise become the document's persisted content type.
+            restoreMediaType(metadata, CONTENT_TYPE_PARSER_OVERRIDE);
+            restoreMediaType(metadata, Metadata.CONTENT_TYPE);
+        }
     }
 
     private static void restoreMediaType(final Metadata metadata, final Property field) {

--- a/extract-lib/src/test/java/org/icij/extract/ocr/OCRParserAdapterTest.java
+++ b/extract-lib/src/test/java/org/icij/extract/ocr/OCRParserAdapterTest.java
@@ -2,11 +2,13 @@ package org.icij.extract.ocr;
 
 import static org.apache.tika.metadata.TikaCoreProperties.CONTENT_TYPE_PARSER_OVERRIDE;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Set;
 
+import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.ParseContext;
@@ -43,6 +45,40 @@ public class OCRParserAdapterTest {
         assertThat(metadata.get(Metadata.CONTENT_TYPE)).isEqualTo("image/jpeg");
         assertThat(metadata.get(CONTENT_TYPE_PARSER_OVERRIDE)).isEqualTo("image/jpeg");
         assertThat(metadata.get(OCRParser.OCR_PARSER)).isEqualTo(NoopParser.class.getName());
+    }
+
+    // Mirrors a failing OCR parse: Tess4JOCRParser rethrows IOException/TikaException (e.g. the OCR
+    // timeout), and EmbedSpawner keeps the embed on parse failure, so the routing type would otherwise
+    // be the content type that gets indexed.
+    private static class ThrowingParser implements Parser {
+        @Override
+        public Set<MediaType> getSupportedTypes(ParseContext context) {
+            return Set.of(MediaType.image("ocr-jpeg"));
+        }
+
+        @Override
+        public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context)
+                throws TikaException {
+            throw new TikaException("OCR timeout");
+        }
+    }
+
+    @Test
+    public void test_restores_real_media_type_when_the_ocr_parse_fails() throws Exception {
+        OCRParserAdapter<ThrowingParser> adapter = new OCRParserAdapter<>(new ThrowingParser());
+        Metadata metadata = new Metadata();
+        metadata.set(CONTENT_TYPE_PARSER_OVERRIDE, "image/ocr-jpeg");
+        metadata.set(Metadata.CONTENT_TYPE, "image/ocr-jpeg");
+
+        try {
+            adapter.parse(new ByteArrayInputStream(new byte[0]), new BodyContentHandler(), metadata, new ParseContext());
+            fail("expected the OCR failure to propagate");
+        } catch (final TikaException e) {
+            assertThat(e.getMessage()).isEqualTo("OCR timeout");
+        }
+
+        assertThat(metadata.get(Metadata.CONTENT_TYPE)).isEqualTo("image/jpeg");
+        assertThat(metadata.get(CONTENT_TYPE_PARSER_OVERRIDE)).isEqualTo("image/jpeg");
     }
 
     @Test


### PR DESCRIPTION
Images whose OCR failed were indexed with Tika's internal routing type (`image/ocr-jpeg`, `image/ocr-png`, ...) as their content type.

`AbstractImageParser` routes an image to OCR by rewriting its media type to `image/ocr-<fmt>` and promoting it onto `Content-Type`. `OCRParserAdapter` undid that only after the delegated parse returned, so when `Tess4JOCRParser` rethrew (most commonly the OCR timeout) the synthetic type stayed on the metadata, and `EmbedSpawner` keeps the embed on parse failure, so it got persisted.

- fix: strip the routing prefix in a `finally` so it is restored on the failure path too
- test: cover a throwing OCR delegate in `OCRParserAdapterTest`

Note: documents already indexed keep their `image/ocr-*` content type and need a reindex.